### PR TITLE
Develop

### DIFF
--- a/config/evaluator_thresholds.yaml
+++ b/config/evaluator_thresholds.yaml
@@ -6,10 +6,16 @@ sharpness:
     excellent: 2312.230796348447
 blurriness:
   discretize_thresholds_raw:
-    bad: 1700.5037249024206
-    poor: 5089.232859428371
-    fair: 16317.690483627226
-    good: 57463.61820005016
+    bad: 0.000683
+    poor: 0.001041
+    fair: 0.002492
+    good: 0.004098
+face_blurriness:
+  discretize_thresholds_raw:
+    bad: 0.000211
+    poor: 0.000306
+    fair: 0.000421
+    good: 0.000612
 contrast:
   discretize_thresholds_raw:
     poor: 17.762808799743652

--- a/docs/evaluators/blurriness_evaluator.md
+++ b/docs/evaluators/blurriness_evaluator.md
@@ -1,0 +1,83 @@
+# BlurrinessEvaluator Design & Contract
+
+## 1. Overview
+
+画像の「ぼやけ（=シャープさ）」を、入力の dtype/スケール差に極力依存しない形で推定し、運用用の5段階離散スコア（blurriness_score）と診断用の生値（blurriness_raw / variance_of_*）を同時に返す評価モジュール。raw はコントラクトとして「高いほど良い（higher_is_better）」に統一し、常に blurriness_raw_direction / blurriness_raw_transform / blurriness_higher_is_better を欠損なく出力する。
+
+---
+
+## 2. Output Contract
+
+### 2.1 Output Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| blurriness_score | float | 5段階離散スコア（1.0 / 0.75 / 0.5 / 0.25 / 0.0）。高いほどシャープで良い。 |
+| blurriness_grade | str | ラベル（excellent / good / fair / blurry / very_blurry）。 |
+| blurriness_raw | float | 診断用の統合raw値（分散特徴の重み付き和）。契約として「高いほど良い（higher_is_better）」を固定する。 |
+| blurriness_raw_direction | str | rawの向き。常に "higher_is_better"。 |
+| blurriness_raw_transform | str | rawの変換。常に "identity"。 |
+| blurriness_higher_is_better | bool | rawの向きのbool表現。常に true。 |
+| blurriness_eval_status | str | 評価状態（ok / fallback / invalid）。 |
+| blurriness_fallback_reason | str|null | fallback/invalid の理由（ok は空文字）。例: invalid_input_not_ndarray / invalid_input_empty / too_small_image_{w}x{h} / non_finite_raw / exception:TypeName |
+| variance_of_gradient | float | Sobel勾配強度（magnitude）の分散。診断用。 |
+| variance_of_laplacian | float | Laplacianの分散。診断用。 |
+| variance_of_difference | float | GaussianBlurとの差分（absdiff）の分散。診断用。 |
+
+
+---
+
+## 3. Purpose
+
+ポートレート評価において「ピントが合っている（シャープ）ほど高評価」を安定して反映する。診断可能性（なぜその評価になったか）を担保しつつ、欠損・異常入力でも破綻しないフォールバックを提供する。さらに、分布チューニング（score_dist_tune）で得た閾値を config の SSOT として管理し、運用中の挙動が再現可能になるようにする。
+
+---
+
+## 4. Algorithm
+
+1) 入力をグレースケール化し、dtype/スケールを吸収して float32[0..1] へ正規化（gray01）。2) Sobel（Tenengrad）から勾配強度を計算し、その分散（variance_of_gradient）を得る。3) Laplacian を計算し、その分散（variance_of_laplacian）を得る。4) GaussianBlur による低周波推定と差分（absdiff）を取り、その分散（variance_of_difference）を得る。5) 3つの分散特徴を重み付き和で統合し、blurriness_raw（高いほど良い）を算出する。6) config の discretize_thresholds_raw（bad/poor/fair/good の4境界）で 5段階（0/0.25/0.5/0.75/1.0）に離散化し、blurriness_score と blurriness_grade を返す。
+
+---
+
+## 5. Normalization Policy
+
+正規化の基本方針は「入力スケール差を評価前に吸収し、特徴量は 0..1 輝度空間で算出する」。具体的には (a) BGR/Gray + uint8/uint16/float を gray01（0..1）へ正規化、(b) Sobel/Laplacian/Diff を float32 で算出、(c) 分散（var）を raw として扱う。これにより 0..255 依存の桁ズレを避け、しきい値（discretize_thresholds_raw）は 1e-4〜1e-2 程度の桁で運用される。
+
+---
+
+## 6. Tuning Integration
+
+分布チューニング（score_dist_tune）は、評価結果CSVの blurriness_raw を対象に、ok行（必要に応じて non-fallback）を母集団として quantile ベースの4境界（12.5/32.5/62.5/87.5%）を算出し、config（blurriness.discretize_thresholds_raw）へ反映する。今回の最新データ（150 samples, all ok）からは bad=0.000683, poor=0.001041, fair=0.002492, good=0.004098 を採用した。
+
+---
+
+## 7. Fallback Policy
+
+入力が ndarray でない、もしくは size==0 の場合は invalid として安全なデフォルト出力を返す（blurriness_eval_status="invalid"、理由を blurriness_fallback_reason に記録）。画像が min_size 未満の場合は fallback として扱い（blurriness_eval_status="fallback"、reason="too_small_image_{w}x{h}"）、診断値（raw/variance）とスコアは算出しつつ、信頼度が低いことを status/reason で明示する。raw が非有限の場合は fallback に遷移し reason="non_finite_raw" を記録する。
+
+---
+
+## 8. Testing
+
+ユニットテストで以下を保証する：1) 基本出力の存在（blurriness_score/blurriness_raw/blurriness_grade/blurriness_eval_status 等）。2) 離散スコアの妥当性（{0,0.25,0.5,0.75,1.0}に収まる）。3) 入力異常耐性（ndarray以外／size0 で必ず安全な出力を返し、status/reason が入る）。4) コントラクト出力（blurriness_raw_direction="higher_is_better"、blurriness_raw_transform="identity"、blurriness_higher_is_better=True）が常に欠損しない。5) しきい値読み込みが config をSSOTとし、単調性（bad<=poor<=fair<=good）が維持される（sortedで事故防止）。
+
+---
+
+## 9. Future Plans
+
+1) face_blurriness（顔領域）で同等の raw/score/contract を整備し、全体との整合を保つ。2) 画像サイズが極端に小さいケースの扱い（fallbackでもscoreを出す/出さない）を運用方針として固定し、tune母集団フィルタ（ok & non-fallback）を標準化する。3) 特徴量のロバスト化（clip_percentile の運用調整、heavy outlier 検知）と、極端条件（夜景・逆光・高ISO）のプロファイル化を検討。4) 分布チューニングの対象期間・対象ファイル選定ルールを明文化し、旧スケール混在を防ぐ（rawスケール契約の維持）。
+
+---
+
+## 10. Design Philosophy
+
+Raw（診断）とScore（運用）を分離し、スコアは比較・合成に強い離散値へ正規化する。異常入力・条件不足を黙殺せず、必ず eval_status と fallback_reason で理由を残す。「落ちない」「追える」「揺れにくい」を優先する。raw の向きは全指標で統一（高いほど良い）し、direction/transform/higher_is_better を常に欠損なく出力する。
+
+---
+
+## 11. Change History
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-02 | raw契約（higher_is_better）と contract keys（raw_direction/raw_transform/higher_is_better）を常時出力する形に統一。dtype/スケール差吸収のため gray01（0..1）正規化を固定し、Sobel/Laplacian/Diff の分散特徴を統合した raw を採用。 | akky0108 |
+| 2026-02 | 分布チューニング（score_dist_tune）により discretize_thresholds_raw を再推定。最新データ（150 samples, all ok）で quantile (12.5/32.5/62.5/87.5) を採用し、bad=0.000683, poor=0.001041, fair=0.002492, good=0.004098 をSSOTとして反映。 | akky0108 |

--- a/src/evaluators/portrait_quality/portrait_quality_evaluator.py
+++ b/src/evaluators/portrait_quality/portrait_quality_evaluator.py
@@ -29,6 +29,7 @@ from evaluators.quality_thresholds import QualityThresholds
 from evaluators.portrait_accept_rules import decide_accept
 from evaluators.portrait_quality.metric_mapping import MetricResultMapper
 
+
 GLOBAL_METRICS = (
     "sharpness",
     "blurriness",
@@ -51,6 +52,7 @@ FACE_REGION_METRICS = (
     "color_balance",
 )
 
+
 class PortraitQualityEvaluator:
     """
     ポートレート画像の品質を多角的に評価するためのクラス。
@@ -66,7 +68,6 @@ class PortraitQualityEvaluator:
         max_noise_value (float): ノイズ評価の正規化上限値
         local_region_size (int): 局所評価時のブロックサイズ
         preprocessor_resize_size (Tuple[int, int]): 前処理時のリサイズサイズ
-
     戻り値:
         Dict[str, Any]: 各評価項目のスコアを格納した辞書
     """
@@ -100,7 +101,23 @@ class PortraitQualityEvaluator:
 
         # --- evaluator 用の閾値/設定（discretize_thresholds_raw 等）をロード ---
         self.eval_config = self._load_evaluator_config()
-        
+
+        # -------------------------
+        # helpers: face_* -> base metric config injection
+        # -------------------------
+        def _subcfg(metric_key: str) -> Dict[str, Any]:
+            """
+            metric_key: "face_blurriness" 等
+            戻り値: evaluator が期待する base key に寄せた dict
+              例: {"blurriness": cfg["face_blurriness"]}
+            """
+            cfg = self.eval_config if isinstance(self.eval_config, dict) else {}
+            spec = cfg.get(metric_key)
+            if not isinstance(spec, dict):
+                return {}
+            base = metric_key.replace("face_", "")
+            return {base: spec}
+
         # 前処理器で画像を一括取得
         self.face_evaluator = FaceEvaluator(backend="insightface")
         self.face_processor = FaceProcessor(self.face_evaluator, logger=self.logger)
@@ -131,7 +148,11 @@ class PortraitQualityEvaluator:
             f"[debug] eval_img dtype={img.dtype}, min={img.min()}, max={img.max()}, mean={img.mean():.2f}"
         )
 
-        self.evaluators = {
+        # -------------------------
+        # evaluators: global / face (separated configs)
+        # -------------------------
+        # global: use full config as-is
+        self.evaluators_global = {
             "face": self.face_evaluator,
             "sharpness": SharpnessEvaluator(logger=self.logger, config=self.eval_config),
             "blurriness": BlurrinessEvaluator(logger=self.logger, config=self.eval_config),
@@ -147,6 +168,23 @@ class PortraitQualityEvaluator:
             "color_balance": ColorBalanceEvaluator(),
         }
 
+        # face: inject face_* thresholds into base metric key expected by evaluator
+        # 例: face_blurriness -> {"blurriness": {...}}
+        self.evaluators_face = {
+            "face": self.face_evaluator,
+            "sharpness": SharpnessEvaluator(logger=self.logger, config=_subcfg("face_sharpness")),
+            "blurriness": BlurrinessEvaluator(logger=self.logger, config=_subcfg("face_blurriness")),
+            "contrast": ContrastEvaluator(logger=self.logger, config=_subcfg("face_contrast")),
+            "noise": NoiseEvaluator(
+                max_noise_value=max_noise_value,
+                logger=self.logger,
+                config=_subcfg("face_noise"),
+            ),
+            "local_sharpness": LocalSharpnessEvaluator(logger=self.logger, config=_subcfg("face_local_sharpness")),
+            "local_contrast": LocalContrastEvaluator(),
+            "exposure": ExposureEvaluator(),
+            "color_balance": ColorBalanceEvaluator(),
+        }
 
         self.body_detector = FullBodyDetector()
         self.mapper = MetricResultMapper()
@@ -162,7 +200,6 @@ class PortraitQualityEvaluator:
 
         # 閾値系の初期化だけ 1 行にまとめる
         self._init_thresholds(quality_profile=quality_profile, thresholds_path=thresholds_path)
-
 
     def _init_thresholds(self, quality_profile: str, thresholds_path: Optional[str]) -> None:
         """
@@ -245,7 +282,7 @@ class PortraitQualityEvaluator:
             "technical_delta_face_sharpness_min": float(decision.get("technical_delta_face_sharpness_min", -15.0)),
             "technical_exposure_min": float(decision.get("technical_exposure_min", 1.0)),
         }
-        
+
     def evaluate(self) -> Dict[str, Any]:
         self.logger.info(f"評価開始: 画像ファイル {self.file_name}")
         results: Dict[str, Any] = {}
@@ -328,12 +365,28 @@ class PortraitQualityEvaluator:
                     self.rgb_u8, best_face, float(results.get("yaw", 0.0))
                 )
 
-                results.update(self._eval_metrics(cropped_face_bgr_u8, FACE_REGION_METRICS, prefix="face_", tag="face"))
+                results.update(
+                    self._eval_metrics(
+                        cropped_face_bgr_u8,
+                        FACE_REGION_METRICS,
+                        prefix="face_",
+                        tag="face",
+                        evaluators_dict=self.evaluators_face,
+                    )
+                )
 
             # -------------------------
             # global metrics
             # -------------------------
-            results.update(self._eval_metrics(self.resized_2048_bgr_u8, GLOBAL_METRICS, prefix="", tag="global"))
+            results.update(
+                self._eval_metrics(
+                    self.resized_2048_bgr_u8,
+                    GLOBAL_METRICS,
+                    prefix="",
+                    tag="global",
+                    evaluators_dict=self.evaluators_global,
+                )
+            )
 
             # -------------------------
             # derived
@@ -358,7 +411,6 @@ class PortraitQualityEvaluator:
             self.logger.error(traceback.format_exc())
             return {}
 
-
     def _evaluate_face(self, evaluator, image):
         """
         顔検出および顔スコアの算出を行う。
@@ -366,7 +418,6 @@ class PortraitQualityEvaluator:
         引数:
             evaluator: 顔評価用の Evaluator インスタンス
             image: 評価対象の画像（RGB形式）
-
         戻り値:
             dict: 顔スコアおよび検出顔情報
         """
@@ -393,18 +444,6 @@ class PortraitQualityEvaluator:
             body_keypoints (list): 全身のキーポイントリスト
         戻り値:
             Dict[str, Any]: 構図に関する各種スコアとグループID情報
-                - composition_rule_based_score
-                - face_position_score
-                - framing_score
-                - face_direction_score
-                - eye_contact_score
-                - face_composition_raw / face_composition_score
-                - body_composition_raw / body_composition_score
-                - composition_raw / composition_score / composition_status
-                - main_subject_center_source / main_subject_center_x / main_subject_center_y
-                - rule_of_thirds_raw / rule_of_thirds_score
-                - contrib_comp_*** 系
-                - group_id / subgroup_id
         """
         try:
             # 顔も全身も情報が全く無ければスキップ
@@ -423,20 +462,17 @@ class PortraitQualityEvaluator:
                     "composition_raw": None,
                     "composition_score": 0.5,
                     "composition_status": "not_computed_with_default",
-                    # RoT / 中心情報
                     "main_subject_center_source": None,
                     "main_subject_center_x": None,
                     "main_subject_center_y": None,
                     "rule_of_thirds_raw": None,
                     "rule_of_thirds_score": None,
-                    # contrib 系（全部 None にしておく）
                     "contrib_comp_composition_rule_based_score": None,
                     "contrib_comp_face_position_score": None,
                     "contrib_comp_framing_score": None,
                     "contrib_comp_lead_room_score": None,
                     "contrib_comp_body_composition_score": None,
                     "contrib_comp_rule_of_thirds_score": None,
-                    # グループ分類
                     "group_id": "unclassified",
                     "subgroup_id": -1,
                 }
@@ -450,58 +486,36 @@ class PortraitQualityEvaluator:
             self.logger.info(f"構図評価結果: {result}")
 
             return {
-                # 顔ルールベースの旧最終スコア（連続値）※後方互換
-                "composition_rule_based_score": result.get(
-                    "composition_rule_based_score", 0.0
-                ),
+                "composition_rule_based_score": result.get("composition_rule_based_score", 0.0),
                 "face_position_score": result.get("face_position_score", 0.0),
                 "framing_score": result.get("framing_score", 0.0),
                 "face_direction_score": result.get("face_direction_score", 0.0),
                 "eye_contact_score": result.get("eye_contact_score", 0.0),
 
-                # 新: 顔構図スコア
                 "face_composition_raw": result.get("face_composition_raw"),
                 "face_composition_score": result.get("face_composition_score"),
 
-                # 新: 全身構図スコア
                 "body_composition_raw": result.get("body_composition_raw"),
                 "body_composition_score": result.get("body_composition_score"),
 
-                # 新: 統合構図スコア
                 "composition_raw": result.get("composition_raw"),
                 "composition_score": result.get("composition_score"),
                 "composition_status": result.get("composition_status", "ok"),
 
-                # メイン被写体中心（RoT 評価に使った点）
                 "main_subject_center_source": result.get("main_subject_center_source"),
                 "main_subject_center_x": result.get("main_subject_center_x"),
                 "main_subject_center_y": result.get("main_subject_center_y"),
 
-                # ルール・オブ・サード評価
                 "rule_of_thirds_raw": result.get("rule_of_thirds_raw"),
                 "rule_of_thirds_score": result.get("rule_of_thirds_score"),
 
-                # 各構図要素の寄与（あればそのまま・なければ None）
-                "contrib_comp_composition_rule_based_score": result.get(
-                    "contrib_comp_composition_rule_based_score"
-                ),
-                "contrib_comp_face_position_score": result.get(
-                    "contrib_comp_face_position_score"
-                ),
-                "contrib_comp_framing_score": result.get(
-                    "contrib_comp_framing_score"
-                ),
-                "contrib_comp_lead_room_score": result.get(
-                    "contrib_comp_lead_room_score"
-                ),
-                "contrib_comp_body_composition_score": result.get(
-                    "contrib_comp_body_composition_score"
-                ),
-                "contrib_comp_rule_of_thirds_score": result.get(
-                    "contrib_comp_rule_of_thirds_score"
-                ),
+                "contrib_comp_composition_rule_based_score": result.get("contrib_comp_composition_rule_based_score"),
+                "contrib_comp_face_position_score": result.get("contrib_comp_face_position_score"),
+                "contrib_comp_framing_score": result.get("contrib_comp_framing_score"),
+                "contrib_comp_lead_room_score": result.get("contrib_comp_lead_room_score"),
+                "contrib_comp_body_composition_score": result.get("contrib_comp_body_composition_score"),
+                "contrib_comp_rule_of_thirds_score": result.get("contrib_comp_rule_of_thirds_score"),
 
-                # グループ分類（どちらかが上書きするが、それでOK）
                 "group_id": result.get("group_id", "unclassified"),
                 "subgroup_id": result.get("subgroup_id", -1),
             }
@@ -521,7 +535,6 @@ class PortraitQualityEvaluator:
                 "composition_raw": None,
                 "composition_score": 0.5,
                 "composition_status": "error_fallback",
-                # RoT / 中心情報もフォールバック値を返す
                 "main_subject_center_source": None,
                 "main_subject_center_x": None,
                 "main_subject_center_y": None,
@@ -533,10 +546,10 @@ class PortraitQualityEvaluator:
                 "contrib_comp_lead_room_score": None,
                 "contrib_comp_body_composition_score": None,
                 "contrib_comp_rule_of_thirds_score": None,
+                "contrib_comp_rule_of_thirds_score": None,
                 "group_id": "unclassified",
                 "subgroup_id": -1,
             }
-        
 
     def _evaluate_face_region(self, face_crop_bgr_u8: np.ndarray) -> Dict[str, Any]:
         """
@@ -544,28 +557,25 @@ class PortraitQualityEvaluator:
         """
         out: Dict[str, Any] = {}
         for name in FACE_REGION_METRICS:
-            evaluator = self.evaluators.get(name)
+            evaluator = self.evaluators_face.get(name)
             if evaluator is None:
                 continue
             r = self._try_eval(evaluator, face_crop_bgr_u8, name=f"face:{name}")
             out.update(self.mapper.map(name, r, prefix="face_"))
         return out
 
-
     # =========================
     # utility
     # =========================
-
-    def _eval_metrics(self, image: np.ndarray, metrics, prefix: str, tag: str) -> Dict[str, Any]:
+    def _eval_metrics(self, image: np.ndarray, metrics, prefix: str, tag: str, evaluators_dict) -> Dict[str, Any]:
         out: Dict[str, Any] = {}
         for name in metrics:
-            evaluator = self.evaluators.get(name)
+            evaluator = evaluators_dict.get(name)
             if evaluator is None:
                 continue
             r = self._try_eval(evaluator, image, name=f"{tag}:{name}")
             out.update(self.mapper.map(name, r, prefix=prefix))
         return out
-
 
     def _ensure_result_schema(self, results: Dict[str, Any]) -> None:
         """
@@ -573,8 +583,6 @@ class PortraitQualityEvaluator:
         - 顔が無い場合: face_* 系は not_computed_with_default / no_face に統一
         - 顔がある場合: 既存値を尊重しつつ欠損だけ埋める
         """
-
-        # --- common ---
         results.setdefault("face_detected", False)
         results.setdefault("faces", [])
         results.setdefault("yaw", 0.0)
@@ -584,26 +592,19 @@ class PortraitQualityEvaluator:
         results.setdefault("lead_room_score", 0.0)
         results.setdefault("face_box_height_ratio", 0.0)
 
-        # --- body defaults（detect実装揺れ対策）---
         results.setdefault("full_body_detected", False)
         results.setdefault("pose_score", 0.0)
         results.setdefault("full_body_cut_risk", 1.0)
 
-        # alias（accept/shot_type が body_center_y を見る可能性に備える）
         if "body_center_y_ratio" in results and "body_center_y" not in results:
             results["body_center_y"] = results.get("body_center_y_ratio")
 
-        # accept 安定化
         results.setdefault("accepted_flag", False)
         results["accepted_reason"] = str(results.get("accepted_reason") or "")
         results.setdefault("shot_type", "unknown")
 
-        # ==========================================================
-        # face_* schema stabilization
-        # ==========================================================
         face_detected = bool(results.get("face_detected"))
 
-        # face系で扱うメトリクス名（MetricResultMapperと対応）
         face_metrics = (
             "sharpness",
             "blurriness",
@@ -615,47 +616,35 @@ class PortraitQualityEvaluator:
             "color_balance",
         )
 
-        # scoreのデフォルト（ニュートラル）
         default_score = {
             "sharpness": 0.5,
             "blurriness": 0.5,
             "contrast": 0.5,
             "noise": 0.5,
-            "local_sharpness": 0.0,   # local系は0でもOK（運用に合わせて0.5でも可）
+            "local_sharpness": 0.0,
             "local_contrast": 0.0,
             "exposure": 0.5,
             "color_balance": 0.5,
         }
 
         if not face_detected:
-            # 顔が無い = 測定不能（悪い評価ではない）
             status = "not_computed_with_default"
             reason = "no_face"
 
             for m in face_metrics:
-                # score本体（最低限）
                 results.setdefault(f"face_{m}_score", default_score.get(m, 0.0))
-
-                # status / reason を必ず揃える（okは禁止）
                 results[f"face_{m}_eval_status"] = status
-
-                # fallback_reason が列として存在するものは埋める（無ければ作ってOK）
-                # 例: noise/exposure/local_* などは今後の分析にも効くので入れちゃう
                 results.setdefault(f"face_{m}_fallback_reason", reason)
 
-            # grade系も顔無しなら not_computed / None 寄せ（列を安定させたいなら）
-            # すでにCSVヘッダにある前提で埋める
             results.setdefault("face_blurriness_grade", None)
             results.setdefault("face_contrast_grade", None)
             results.setdefault("face_noise_grade", None)
             results.setdefault("face_exposure_grade", None)
             results.setdefault("face_color_balance_grade", None)
 
-            # local系 std も安定化
             results.setdefault("face_local_sharpness_std", 0.0)
             results.setdefault("face_local_contrast_std", 0.0)
 
-            # face系 raw（必要ならNoneで固定）
             results.setdefault("face_sharpness_raw", None)
             results.setdefault("face_blurriness_raw", None)
             results.setdefault("face_contrast_raw", None)
@@ -663,29 +652,18 @@ class PortraitQualityEvaluator:
             results.setdefault("face_noise_raw", None)
 
         else:
-            # 顔がある場合：欠損だけ埋める（statusが無いなら ok 扱いにしてよい）
             for m in face_metrics:
                 results.setdefault(f"face_{m}_score", default_score.get(m, 0.0))
                 results.setdefault(f"face_{m}_eval_status", "ok")
-                # fallback_reason は ok のとき空欄でOK（埋めない）
-
 
     def _normalize_for_csv(self, results: Dict[str, Any]) -> None:
-        # faces はCSVに安全に載る形式へ（list/dict -> 文字列）
         faces = results.get("faces", [])
         if isinstance(faces, (list, dict)):
             results["faces"] = str(faces)
         else:
             results["faces"] = str(faces)
 
-
     def _calc_lead_room_score(self, image: np.ndarray, best_face: Dict[str, Any], yaw: float) -> float:
-        """
-        視線（yaw）の向きに余白があるほど +、逆なら -。
-        返り値: [-1, 1]
-
-        best_face["box"] は [x1, y1, x2, y2] を想定。
-        """
         h, W = image.shape[:2]
         box = best_face.get("box")
         if not box or len(box) != 4:
@@ -697,15 +675,14 @@ class PortraitQualityEvaluator:
         left_space = cx
         right_space = W - cx
 
-        if yaw > 5:       # 右向き想定
+        if yaw > 5:
             raw = (right_space - left_space) / W
-        elif yaw < -5:    # 左向き想定
+        elif yaw < -5:
             raw = (left_space - right_space) / W
         else:
             raw = 0.0
 
         return float(max(-1.0, min(1.0, raw)))
-
 
     def _add_face_global_deltas(self, results: Dict[str, Any]) -> None:
         def d(a, b):
@@ -723,15 +700,7 @@ class PortraitQualityEvaluator:
             results.get("face_contrast_score"), results.get("contrast_score")
         )
 
-
     def _add_expression_score(self, results: Dict[str, Any]) -> None:
-        """
-        既存の face 向き系の指標から簡易 expression_score (0〜1) を作る。
-
-        - eye_contact_score / face_direction_score をベースに加点
-        - yaw / pitch が大きいと減点
-        """
-
         def _f(key: str, default: float = 0.0) -> float:
             v = results.get(key, default)
             try:
@@ -744,23 +713,14 @@ class PortraitQualityEvaluator:
         yaw = abs(_f("yaw", 0.0))
         pitch = abs(_f("pitch", 0.0))
 
-        # ベースは「目線＋顔の向き」
-        base = 0.6 * eye_contact + 0.4 * face_direction  # 0〜1 前提
-
-        # yaw/pitch が大きすぎると減点（45度超えたら最大ペナルティ）
+        base = 0.6 * eye_contact + 0.4 * face_direction
         yaw_penalty = min(yaw / 45.0, 1.0)
         pitch_penalty = min(pitch / 45.0, 1.0)
-
-        # ペナルティを 0〜1 にまとめる（0: 正面〜少し横, 1: 真横＆うつむき/のけ反り）
         penalty = 0.5 * yaw_penalty + 0.5 * pitch_penalty
-
-        # ペナルティを 0〜0.4 くらいの係数で効かせる（お好みで調整可）
         score = base * (1.0 - 0.4 * penalty)
 
-        # クリップ
         score = max(0.0, min(1.0, score))
 
-        # グレード分類
         if score >= 0.9:
             grade = "excellent"
         elif score >= 0.75:
@@ -775,7 +735,6 @@ class PortraitQualityEvaluator:
         results["expression_score"] = score
         results["expression_grade"] = grade
 
-
     def _try_eval(self, evaluator, image: np.ndarray, name: str) -> Dict[str, Any]:
         try:
             return evaluator.evaluate(image) or {}
@@ -783,7 +742,6 @@ class PortraitQualityEvaluator:
             self.logger.error(f"{name} evaluate failed: {e}")
             self.logger.error(traceback.format_exc())
             return {}
-
 
     def _load_evaluator_config(self) -> Dict[str, Any]:
         """
@@ -793,7 +751,6 @@ class PortraitQualityEvaluator:
         config_manager があればそこからパスを取得。
         無ければデフォルトパスを読む。読めない場合は {} を返す。
         """
-        # パス決定
         path = None
         if self.config_manager is not None:
             try:
@@ -806,7 +763,6 @@ class PortraitQualityEvaluator:
         else:
             path = "config/evaluator_thresholds.yaml"
 
-        # 読み込み
         try:
             if not path or not isinstance(path, str):
                 return {}
@@ -828,11 +784,9 @@ class PortraitQualityEvaluator:
             self.logger.warning(f"Evaluator config load failed: {e} (use defaults)")
             return {}
 
-
     @staticmethod
     def decide_accept_static(
         results: Dict[str, Any],
         thresholds: Optional[Dict[str, float]] = None,
     ) -> Tuple[bool, str]:
         return decide_accept(results, thresholds=thresholds)
-


### PR DESCRIPTION
### 概要
- #702 系（Blurriness / FaceBlurriness）の対応を main に統合
- raw 分布に基づく閾値再設計を反映
- 顔用 blurriness の独立管理を完了

### 変更内容
- blurriness / face_blurriness の discretize_thresholds_raw を更新
- 最新データ（150枚）で再チューニング済み
- score 分布・accept 判定への影響を確認

### 状態
- 関連 Issue（#702-2 / #702-3）対応完了
- 既存評価パイプラインとの整合性確認済み

Ready for merge.
