### PR TITLE
feat(#702-4): 明るさ補正検証ツールを実装（FACE対応・SSOT出力・後方互換あり）

### DIFF
--- a/src/photo_insight/batch_processor/evaluation_rank/contract.py
+++ b/src/photo_insight/batch_processor/evaluation_rank/contract.py
@@ -2,9 +2,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-# contract.py
-from __future__ import annotations
-
 from pathlib import Path
 from typing import List, Sequence
 
@@ -158,6 +155,10 @@ OUTPUT_COLUMNS = [
     "accepted_flag",
     "secondary_accept_flag",
     "blurriness_score",
+    "blurriness_score_brightness_adjusted",
+    "blurriness_raw",
+    "blurriness_grade",
+    "mean_brightness",
     "sharpness_score",
     "contrast_score",
     "noise_score",
@@ -168,6 +169,11 @@ OUTPUT_COLUMNS = [
     "face_noise_score",
     "face_local_sharpness_score",
     "face_local_contrast_score",
+    "face_blurriness_score",
+    "face_blurriness_score_brightness_adjusted",
+    "face_blurriness_raw",
+    "face_blurriness_grade",
+    "face_mean_brightness",
     "composition_rule_based_score",
     "face_position_score",
     "framing_score",

--- a/src/tools/brightness_comp_validate.py
+++ b/src/tools/brightness_comp_validate.py
@@ -1,0 +1,366 @@
+# src/tools/brightness_comp_validate.py
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import glob as _glob
+
+
+# =========================
+# SSOT: Output contract
+# =========================
+SCHEMA_VERSION = "1.2"
+
+SUMMARY_FILENAME = "brightness_validation_summary.json"
+
+# ★ 既存テスト互換: pairs CSV 名を export
+PAIRS_FILENAME = "brightness_validation_pairs.csv"
+
+
+# =========================
+# SSOT: file discovery
+# =========================
+RANKING_PATTERN = "evaluation_ranking_*.csv"
+DATE_RE = re.compile(r"evaluation_ranking_(\d{4}-\d{2}-\d{2})\.csv")
+
+
+# =========================
+# SSOT: metrics
+# =========================
+# NOTE:
+# - face_blurriness は face_mean_brightness を優先し、無い/不正なら mean_brightness へフォールバック
+# - face_noise は「adjusted列」が現状パイプラインに無さそうなので今回は未登録（将来追加）
+METRICS: Dict[str, Dict[str, Any]] = {
+    "blurriness": {
+        "score_col": "blurriness_score",
+        "score_adj_col": "blurriness_score_brightness_adjusted",
+        "raw_col": "blurriness_raw",
+        "brightness_cols": ["mean_brightness"],
+    },
+    "noise": {
+        "score_col": "noise_score",
+        "score_adj_col": "noise_score_brightness_adjusted",
+        "raw_col": "noise_raw",
+        "brightness_cols": ["mean_brightness"],
+    },
+    "face_blurriness": {
+        "score_col": "face_blurriness_score",
+        "score_adj_col": "face_blurriness_score_brightness_adjusted",
+        "raw_col": "face_blurriness_raw",
+        "brightness_cols": ["face_mean_brightness", "mean_brightness"],  # ★fallback
+    },
+}
+
+
+# =========================
+# utils
+# =========================
+
+def _now_iso_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _to_float(x: Any) -> Optional[float]:
+    try:
+        if x in ("", None):
+            return None
+        v = float(x)
+        if math.isnan(v) or math.isinf(v):
+            return None
+        return v
+    except Exception:
+        return None
+
+
+def _to_bool(x: Any) -> bool:
+    if isinstance(x, bool):
+        return x
+    if x in ("", None):
+        return False
+    s = str(x).strip().lower()
+    if s in ("1", "true", "t", "yes", "y"):
+        return True
+    if s in ("0", "false", "f", "no", "n"):
+        return False
+    try:
+        return bool(int(float(s)))
+    except Exception:
+        return False
+
+
+def _pearson(xs: List[float], ys: List[float]) -> Optional[float]:
+    n = len(xs)
+    if n < 2:
+        return None
+    mx = sum(xs) / n
+    my = sum(ys) / n
+    vx = sum((x - mx) ** 2 for x in xs)
+    vy = sum((y - my) ** 2 for y in ys)
+    if vx <= 0 or vy <= 0:
+        return None
+    cov = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    return cov / math.sqrt(vx * vy)
+
+
+def _extract_date_from_name(name: str) -> Optional[str]:
+    m = DATE_RE.match(name)
+    return m.group(1) if m else None
+
+
+def discover_ranking_files(*, root_dir: Path, date: Optional[str]) -> List[str]:
+    """
+    SSOT:
+    - date 指定あり → evaluation_ranking_{date}.csv のみ（最大1件）
+    - date なし → 最新日付の 1件のみ（最大1件）
+    """
+    if not root_dir.exists():
+        return []
+
+    all_files = sorted(root_dir.rglob(RANKING_PATTERN))
+    if not all_files:
+        return []
+
+    if date:
+        target_name = f"evaluation_ranking_{date}.csv"
+        matches = [str(p) for p in all_files if p.name == target_name]
+        return matches[:1]
+
+    dated: List[Tuple[str, Path]] = []
+    for p in all_files:
+        d = _extract_date_from_name(p.name)
+        if d:
+            dated.append((d, p))
+    if not dated:
+        return []
+
+    dated.sort(key=lambda x: x[0], reverse=True)
+    return [str(dated[0][1])]
+
+
+def _read_rows(path: Path) -> List[Dict[str, Any]]:
+    with path.open("r", encoding="utf-8", newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def _pick_brightness(row: Dict[str, Any], brightness_cols: List[str]) -> Optional[float]:
+    for col in brightness_cols:
+        v = _to_float(row.get(col))
+        if v is not None:
+            return v
+    return None
+
+
+def _metric_summary(
+    *,
+    rows: List[Dict[str, Any]],
+    score_col: str,
+    score_adj_col: str,
+    raw_col: str,
+    brightness_cols: List[str],
+) -> Dict[str, Any]:
+    xs, ys, rs, bs, deltas = [], [], [], [], []
+
+    for r in rows:
+        s = _to_float(r.get(score_col))
+        a = _to_float(r.get(score_adj_col))
+        raw = _to_float(r.get(raw_col))
+        b = _pick_brightness(r, brightness_cols)
+
+        if None in (s, a, raw, b):
+            continue
+
+        xs.append(s)
+        ys.append(a)
+        rs.append(raw)
+        bs.append(b)
+        deltas.append(a - s)
+
+    abs_d = sorted(abs(d) for d in deltas)
+
+    return {
+        "score_col": score_col,
+        "score_adj_col": score_adj_col,
+        "raw_col": raw_col,
+        "brightness_cols": list(brightness_cols),
+        "n": len(xs),
+        "corr_score_vs_adj": _pearson(xs, ys),
+        "corr_raw_vs_adj": _pearson(rs, ys),
+        "corr_brightness_vs_delta": _pearson(bs, deltas),
+        "mean_delta": (sum(deltas) / len(deltas)) if deltas else 0.0,
+        "median_delta": (sorted(deltas)[len(deltas)//2] if deltas else 0.0),
+        "p95_abs_delta": (abs_d[int(0.95 * len(abs_d))] if abs_d else 0.0),
+    }
+
+
+def _split_rows(rows: List[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    all / face / non_face に分割
+    """
+    face = []
+    non_face = []
+    for r in rows:
+        if _to_bool(r.get("face_detected")):
+            face.append(r)
+        else:
+            non_face.append(r)
+    return {"all": rows, "face": face, "non_face": non_face}
+
+
+def _write_pairs_csv(
+    *,
+    out_path: Path,
+    rows: List[Dict[str, Any]],
+) -> None:
+    """
+    ★ 既存テスト互換: emit_pairs_csv=True のときに出す。
+    各行×metric の “score→adjusted の差” を行で出力。
+    """
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    header = [
+        "metric",
+        "file_name",
+        "face_detected",
+        "brightness",
+        "score",
+        "adjusted_score",
+        "delta",
+    ]
+
+    with out_path.open("w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=header)
+        w.writeheader()
+
+        for r in rows:
+            fname = str(r.get("file_name") or r.get("filename") or "")
+            face_detected = 1 if _to_bool(r.get("face_detected")) else 0
+
+            for mname, spec in METRICS.items():
+                s = _to_float(r.get(spec["score_col"]))
+                a = _to_float(r.get(spec["score_adj_col"]))
+                b = _pick_brightness(r, spec["brightness_cols"])
+                if None in (s, a, b):
+                    continue
+
+                w.writerow(
+                    {
+                        "metric": mname,
+                        "file_name": fname,
+                        "face_detected": face_detected,
+                        "brightness": b,
+                        "score": s,
+                        "adjusted_score": a,
+                        "delta": a - s,
+                    }
+                )
+
+
+# =========================
+# public API (backward-compatible)
+# =========================
+
+def run(
+    *,
+    # --- new style ---
+    root_dir: Optional[Path] = None,
+    date: Optional[str] = None,
+    # --- legacy style (tests/unit/tools/test_brightness_compensation_verify_tool.py 互換) ---
+    ranking_glob: Optional[str] = None,
+    # --- outputs ---
+    out_dir: Path,
+    emit_pairs_csv: bool = False,
+) -> Path:
+    """
+    後方互換を維持した run()
+
+    - 新: run(root_dir=Path("output"), date="YYYY-MM-DD", out_dir=Path(...))
+    - 旧: run(ranking_glob="output/**/evaluation_ranking_*.csv", out_dir=..., emit_pairs_csv=True)
+    """
+    files: List[str] = []
+
+    if ranking_glob:
+        files = sorted(_glob.glob(ranking_glob, recursive=True))
+    else:
+        rd = root_dir or Path("output")
+        files = discover_ranking_files(root_dir=rd, date=date)
+
+    rows: List[Dict[str, Any]] = []
+    for f in files:
+        p = Path(f)
+        if p.exists():
+            rows.extend(_read_rows(p))
+
+    groups = _split_rows(rows)
+
+    metrics_out: Dict[str, Any] = {}
+    for name, spec in METRICS.items():
+        per_group: Dict[str, Any] = {}
+        for gname, grows in groups.items():
+            per_group[gname] = _metric_summary(rows=grows, **spec)
+        metrics_out[name] = per_group
+
+    summary = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": _now_iso_utc(),
+        "inputs": {
+            "root_dir": str(root_dir) if root_dir is not None else None,
+            "date": date,
+            "ranking_glob": ranking_glob,
+            "ranking_files": files,
+            "n_files": len(files),
+            "n_rows": len(rows),
+            "n_rows_face": len(groups["face"]),
+            "n_rows_non_face": len(groups["non_face"]),
+        },
+        "metrics": metrics_out,
+        "notes": {
+            "groups": ["all", "face", "non_face"],
+            "face_blurriness_brightness_fallback": "face_mean_brightness -> mean_brightness",
+        },
+    }
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = out_dir / SUMMARY_FILENAME
+    summary_path.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    if emit_pairs_csv:
+        pairs_path = out_dir / PAIRS_FILENAME
+        _write_pairs_csv(out_path=pairs_path, rows=rows)
+
+    return summary_path
+
+
+# =========================
+# CLI
+# =========================
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--root-dir", default="output")
+    p.add_argument("--date", default=None)
+    p.add_argument("--ranking-glob", default=None)
+    p.add_argument("--out-dir", default="output/brightness_validation")
+    p.add_argument("--emit-pairs-csv", action="store_true")
+    args = p.parse_args()
+
+    run(
+        root_dir=Path(args.root_dir) if args.ranking_glob is None else None,
+        date=args.date,
+        ranking_glob=args.ranking_glob,
+        out_dir=Path(args.out_dir),
+        emit_pairs_csv=bool(args.emit_pairs_csv),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/tools/test_brightness_comp_validate_discovery.py
+++ b/tests/unit/tools/test_brightness_comp_validate_discovery.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import sys
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.tools.brightness_comp_validate import discover_ranking_files
+
+
+def _touch(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("dummy", encoding="utf-8")
+
+
+def test_discover_latest_only(tmp_path: Path) -> None:
+    root = tmp_path / "output"
+
+    _touch(root / "a" / "evaluation_ranking_2026-02-10.csv")
+    _touch(root / "b" / "evaluation_ranking_2026-02-11.csv")
+
+    files = discover_ranking_files(root_dir=root, date=None)
+
+    assert len(files) == 1
+    assert files[0].endswith("2026-02-11.csv")
+
+
+def test_discover_specific_date(tmp_path: Path) -> None:
+    root = tmp_path / "output"
+
+    _touch(root / "x" / "evaluation_ranking_2026-02-09.csv")
+    _touch(root / "y" / "evaluation_ranking_2026-02-11.csv")
+
+    files = discover_ranking_files(root_dir=root, date="2026-02-09")
+
+    assert len(files) == 1
+    assert files[0].endswith("2026-02-09.csv")

--- a/tests/unit/tools/test_brightness_comp_validate_face_metrics.py
+++ b/tests/unit/tools/test_brightness_comp_validate_face_metrics.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import sys
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.tools.brightness_comp_validate import run, SCHEMA_VERSION
+
+
+def _write_ranking_csv(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    header = [
+        "file_name",
+        "face_detected",
+        "mean_brightness",
+        "face_mean_brightness",
+        "blurriness_score",
+        "blurriness_score_brightness_adjusted",
+        "blurriness_raw",
+        "noise_score",
+        "noise_score_brightness_adjusted",
+        "noise_raw",
+        "face_blurriness_score",
+        "face_blurriness_score_brightness_adjusted",
+        "face_blurriness_raw",
+    ]
+
+    # 2行、face_detected=True で face_* が有効
+    rows = [
+        {
+            "file_name": "a.jpg",
+            "face_detected": "1",
+            "mean_brightness": "0.10",
+            "face_mean_brightness": "0.12",
+            "blurriness_score": "0.50",
+            "blurriness_score_brightness_adjusted": "0.75",
+            "blurriness_raw": "0.002",
+            "noise_score": "0.50",
+            "noise_score_brightness_adjusted": "0.60",
+            "noise_raw": "-0.001",
+            "face_blurriness_score": "0.50",
+            "face_blurriness_score_brightness_adjusted": "0.80",
+            "face_blurriness_raw": "0.0005",
+        },
+        {
+            "file_name": "b.jpg",
+            "face_detected": "1",
+            "mean_brightness": "0.20",
+            "face_mean_brightness": "0.22",
+            "blurriness_score": "0.50",
+            "blurriness_score_brightness_adjusted": "0.70",
+            "blurriness_raw": "0.003",
+            "noise_score": "0.50",
+            "noise_score_brightness_adjusted": "0.55",
+            "noise_raw": "-0.0012",
+            "face_blurriness_score": "0.50",
+            "face_blurriness_score_brightness_adjusted": "0.78",
+            "face_blurriness_raw": "0.0006",
+        },
+    ]
+
+    with path.open("w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=header)
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+
+
+def test_face_metrics_present(tmp_path: Path) -> None:
+    ranking_csv = tmp_path / "output" / "x" / "evaluation_ranking_2026-02-11.csv"
+    _write_ranking_csv(ranking_csv)
+
+    out_dir = tmp_path / "out"
+    summary_path = run(root_dir=tmp_path / "output", date=None, out_dir=out_dir)
+
+    data = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert data["schema_version"] == SCHEMA_VERSION
+
+    assert "face_blurriness" in data["metrics"]
+    assert "all" in data["metrics"]["face_blurriness"]
+    assert data["metrics"]["face_blurriness"]["all"]["n"] == 2

--- a/tests/unit/tools/test_brightness_comp_validate_group_split.py
+++ b/tests/unit/tools/test_brightness_comp_validate_group_split.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import sys
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.tools.brightness_comp_validate import run
+
+
+def _write_ranking_csv(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    header = [
+        "file_name",
+        "face_detected",
+        "mean_brightness",
+        "face_mean_brightness",
+        "blurriness_score",
+        "blurriness_score_brightness_adjusted",
+        "blurriness_raw",
+        "noise_score",
+        "noise_score_brightness_adjusted",
+        "noise_raw",
+        "face_blurriness_score",
+        "face_blurriness_score_brightness_adjusted",
+        "face_blurriness_raw",
+    ]
+
+    # face 2行、non_face 1行（non_face は face_* を欠損にして n=0 になる想定）
+    rows = [
+        {
+            "file_name": "face1.jpg",
+            "face_detected": "1",
+            "mean_brightness": "0.10",
+            "face_mean_brightness": "0.12",
+            "blurriness_score": "0.50",
+            "blurriness_score_brightness_adjusted": "0.75",
+            "blurriness_raw": "0.002",
+            "noise_score": "0.50",
+            "noise_score_brightness_adjusted": "0.60",
+            "noise_raw": "-0.001",
+            "face_blurriness_score": "0.50",
+            "face_blurriness_score_brightness_adjusted": "0.80",
+            "face_blurriness_raw": "0.0005",
+        },
+        {
+            "file_name": "face2.jpg",
+            "face_detected": "true",
+            "mean_brightness": "0.20",
+            "face_mean_brightness": "0.22",
+            "blurriness_score": "0.50",
+            "blurriness_score_brightness_adjusted": "0.70",
+            "blurriness_raw": "0.003",
+            "noise_score": "0.50",
+            "noise_score_brightness_adjusted": "0.55",
+            "noise_raw": "-0.0012",
+            "face_blurriness_score": "0.50",
+            "face_blurriness_score_brightness_adjusted": "0.78",
+            "face_blurriness_raw": "0.0006",
+        },
+        {
+            "file_name": "nonface.jpg",
+            "face_detected": "0",
+            "mean_brightness": "0.30",
+            "face_mean_brightness": "",
+            "blurriness_score": "0.50",
+            "blurriness_score_brightness_adjusted": "0.65",
+            "blurriness_raw": "0.004",
+            "noise_score": "0.50",
+            "noise_score_brightness_adjusted": "0.52",
+            "noise_raw": "-0.0015",
+            "face_blurriness_score": "",
+            "face_blurriness_score_brightness_adjusted": "",
+            "face_blurriness_raw": "",
+        },
+    ]
+
+    with path.open("w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=header)
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+
+
+def test_group_split_counts(tmp_path: Path) -> None:
+    ranking_csv = tmp_path / "output" / "x" / "evaluation_ranking_2026-02-11.csv"
+    _write_ranking_csv(ranking_csv)
+
+    out_dir = tmp_path / "out"
+    summary_path = run(root_dir=tmp_path / "output", date=None, out_dir=out_dir)
+    data = json.loads(summary_path.read_text(encoding="utf-8"))
+
+    assert data["inputs"]["n_rows"] == 3
+    assert data["inputs"]["n_rows_face"] == 2
+    assert data["inputs"]["n_rows_non_face"] == 1
+
+    # face_blurriness: face group は2件、non_face group は0件（欠損のため）
+    fb = data["metrics"]["face_blurriness"]
+    assert fb["face"]["n"] == 2
+    assert fb["non_face"]["n"] == 0

--- a/tests/unit/tools/test_brightness_compensation_verify_tool.py
+++ b/tests/unit/tools/test_brightness_compensation_verify_tool.py
@@ -1,0 +1,97 @@
+# tests/unit/tools/test_brightness_comp_validate.py
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+# --- make tools importable ---
+import sys
+from pathlib import Path as _Path
+REPO_ROOT = _Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.tools.brightness_comp_validate import (  # type: ignore
+    run,
+    SCHEMA_VERSION,
+    SUMMARY_FILENAME,
+    PAIRS_FILENAME,
+)
+
+
+def _write_ranking_csv(path: Path) -> None:
+    """
+    brightness_comp_validate が読むのは ranking CSV。
+    必須列だけ用意して、最小で動くようにする。
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    header = [
+        "file_name",
+        "mean_brightness",
+        "blurriness_score",
+        "blurriness_score_brightness_adjusted",
+        "blurriness_raw",
+        "noise_score",
+        "noise_score_brightness_adjusted",
+        "noise_raw",
+    ]
+    rows = [
+        {
+            "file_name": "a.jpg",
+            "mean_brightness": "0.10",
+            "blurriness_score": "0.75",
+            "blurriness_score_brightness_adjusted": "0.70",
+            "blurriness_raw": "0.0010",
+            "noise_score": "0.50",
+            "noise_score_brightness_adjusted": "0.55",
+            "noise_raw": "-0.0012",
+        },
+        {
+            "file_name": "b.jpg",
+            "mean_brightness": "0.80",
+            "blurriness_score": "0.25",
+            "blurriness_score_brightness_adjusted": "0.30",
+            "blurriness_raw": "0.0020",
+            "noise_score": "0.75",
+            "noise_score_brightness_adjusted": "0.70",
+            "noise_raw": "-0.0009",
+        },
+    ]
+
+    # 手書きCSV（csvモジュール使わずに依存減らす）
+    lines = [",".join(header)]
+    for r in rows:
+        lines.append(",".join(str(r.get(c, "")) for c in header))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_brightness_comp_validate_writes_ssot_outputs(tmp_path: Path) -> None:
+    # arrange
+    out_dir = tmp_path / "out"
+    ranking_dir = tmp_path / "output" / "x"
+    ranking_csv = ranking_dir / "evaluation_ranking_2026-02-11.csv"
+    _write_ranking_csv(ranking_csv)
+
+    # act（★ 新API）
+    summary_path = run(
+        root_dir=tmp_path / "output",
+        date=None,  # 最新1件を自動選択
+        out_dir=out_dir,
+    )
+
+    # assert: SSOT files exist
+    assert summary_path.exists()
+
+    data = json.loads(summary_path.read_text(encoding="utf-8"))
+
+    assert data["schema_version"] == SCHEMA_VERSION
+    assert "generated_at" in data
+
+    assert data["inputs"]["n_files"] == 1
+    assert data["inputs"]["n_rows"] == 2
+
+    assert "metrics" in data
+    assert "blurriness" in data["metrics"]
+    assert "noise" in data["metrics"]
+


### PR DESCRIPTION
[#702-4] 明るさ補正検証ツールの基盤実装

evaluation_ranking CSV を入力として、
明るさ補正前後のスコア差分・相関を定量検証するツールを追加。

主な機能:

- ranking CSV 自動探索（output/**/evaluation_ranking_*.csv）
- blurriness / noise / face_blurriness の検証
- face_detected による母集団分割
- SSOT JSON 出力
- デバッグ用 pairs CSV 出力
- 後方互換API維持

本コミットでは検証基盤のみを実装。
評価基準（pass/fail）は次段階で追加予定。
