### PR TITLE
CI v2: Compose-based ci-light

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -1,0 +1,13 @@
+name: CI Full (manual)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  full:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          docker compose build app-ci
+          docker compose run --rm app-ci make ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,30 +8,20 @@ on:
       - develop
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
 
-      - name: Choose Make target
-        id: tgt
+      - name: Build (compose)
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "make_target=ci-light" >> $GITHUB_OUTPUT
-          else
-            echo "make_target=ci" >> $GITHUB_OUTPUT
-          fi
+          docker compose build app-ci
 
-      - name: Build CI image (CPU)
+      - name: CI Light (compose)
         run: |
-          docker build --target ci -t photo_insight-ci:local .
-
-      - name: Run in container
-        run: |
-          docker run --rm \
-            -v "${{ github.workspace }}:/work" \
-            -w /work \
-            photo_insight-ci:local \
-            make ${{ steps.tgt.outputs.make_target }}
+          docker compose run --rm app-ci make ci-light

--- a/Makefile
+++ b/Makefile
@@ -82,10 +82,10 @@ test-light:
 	$(PYTEST) -q tests/unit -m "not heavy"
 
 test-heavy:
-	pytest -q -m "heavy" --run-heavy
+	$(PYTEST) -q -m "heavy" --run-heavy
 
 test-integration:
-	pytest -q tests/integration -m "integration" --run-heavy
+	$(PYTEST) -q tests/integration -m "integration" --run-heavy
 
 ci: fmt-check lint test
 ci-light: fmt-check lint test-light

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,22 @@ services:
     command: bash
     tty: true
 
+  # CI専用
+  app-ci:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: ci
+    working_dir: /work
+    volumes:
+      - ./:/work:cached
+      - pip-cache:/root/.cache/pip
+    environment:
+      - PYTHONUNBUFFERED=1
+      - PYTHONPATH=/work/src
+    command: make ci-light
+    tty: false
+
   app-gpu:
     build:
       context: .


### PR DESCRIPTION
1.CI を docker compose run --rm app-ci make ci-light に統一
2.Dockerが正規実行環境のため、compose.yaml を唯一の仕様に寄せた
3.PR/Pushともに安定ゲートは ci-light（フルは ci-full workflow_dispatch）