### PR TITLE
refactor(cli): route processors through pipelines entrypoints

### DIFF
--- a/src/photo_insight/cli/run_batch.py
+++ b/src/photo_insight/cli/run_batch.py
@@ -38,21 +38,17 @@ def _load_processor_by_alias(name: str) -> Type[BaseBatchProcessor]:
     key = (name or "").strip().lower()
 
     if key in ("nef", "nef_file", "nef_file_batch"):
-        from photo_insight.pipelines.nef_batch_process import NEFFileBatchProcess
+        from photo_insight.pipelines.nef.nef_batch_process import NEFFileBatchProcess
 
         return NEFFileBatchProcess
 
     if key in ("evaluation_rank", "rank", "eval_rank"):
-        from photo_insight.batch_processor.evaluation_rank.evaluation_rank_batch_processor import (  # noqa: E501,E402
-            EvaluationRankBatchProcessor,
-        )
+        from photo_insight.pipelines.evaluation_rank import EvaluationRankBatchProcessor
 
         return EvaluationRankBatchProcessor
 
     if key in ("portrait_quality", "quality", "portrait"):
-        from photo_insight.batch_processor.portrait_quality import (
-            PortraitQualityBatchProcessor,
-        )
+        from photo_insight.pipelines.portrait_quality import PortraitQualityBatchProcessor
 
         return PortraitQualityBatchProcessor
 

--- a/src/photo_insight/pipelines/evaluation_rank/__init__.py
+++ b/src/photo_insight/pipelines/evaluation_rank/__init__.py
@@ -1,0 +1,8 @@
+"""
+Pipelines entrypoint for evaluation_rank.
+Currently delegates to legacy batch_processor implementation for compatibility.
+"""
+
+from photo_insight.batch_processor.evaluation_rank.evaluation_rank_batch_processor import EvaluationRankBatchProcessor
+
+__all__ = ["EvaluationRankBatchProcessor"]

--- a/src/photo_insight/pipelines/portrait_quality/__init__.py
+++ b/src/photo_insight/pipelines/portrait_quality/__init__.py
@@ -1,0 +1,8 @@
+"""
+Pipelines entrypoint for portrait_quality.
+Currently delegates to legacy batch_processor implementation for compatibility.
+"""
+
+from photo_insight.batch_processor.portrait_quality import PortraitQualityBatchProcessor
+
+__all__ = ["PortraitQualityBatchProcessor"]

--- a/src/photo_insight/portrait_quality_batch_processor.py
+++ b/src/photo_insight/portrait_quality_batch_processor.py
@@ -1,3 +1,3 @@
-from photo_insight.batch_processor.portrait_quality import PortraitQualityBatchProcessor
+from photo_insight.pipelines.portrait_quality import PortraitQualityBatchProcessor
 
 __all__ = ["PortraitQualityBatchProcessor"]


### PR DESCRIPTION
run_batch.py の alias 解決を pipelines 側に統一（NEF/evaluation_rank/portrait_quality）
pipelines に evaluation_rank / portrait_quality の entrypoint を追加（当面は legacy に委譲）
portrait_quality_batch_processor.py も pipelines import に変更