### PR TITLE
fix(portrait_quality): apply max_images before setup via execute

### DIFF
--- a/src/photo_insight/pipelines/portrait_quality/portrait_quality_batch_processor.py
+++ b/src/photo_insight/pipelines/portrait_quality/portrait_quality_batch_processor.py
@@ -97,6 +97,15 @@ class PortraitQualityBatchProcessor(BaseBatchProcessor):
     # ============================================================
     # ★ run_batch 互換: Base.process(**kwargs) で渡される max_images を吸収
     # ============================================================
+    def execute(self, *args: Any, max_images: Optional[int] = None, **kwargs: Any) -> None:
+        """
+        setup() より前に run 固有条件を反映する。
+        max_images は load_data() に効かせたいので execute() で受ける。
+        """
+        if max_images is not None:
+            self.max_images = max_images
+        return super().execute(*args, **kwargs)
+
     def process(self, *args: Any, max_images: Optional[int] = None, **kwargs: Any):
         """
         BaseBatchProcessor.process() が受け取らない kwargs（例: max_images）を、


### PR DESCRIPTION
## 概要
PortraitQualityBatchProcessor で `--max-images` が setup 前に反映されない問題を修正しました。

## 背景
BaseBatchProcessor の lifecycle は `execute -> setup -> process -> cleanup` です。
従来は `process(max_images=...)` で `self.max_images` を反映していたため、
`setup()` 内の `load_data()` 実行時には max_images が未反映でした。

その結果:
- `unexpected keyword argument 'max_images'` は回避できる
- ただし load_data() では全件が対象になり、件数制限が効かない

## 対応内容
- `PortraitQualityBatchProcessor.execute()` を override
- `setup()` より前に `self.max_images` を反映するよう修正
- 既存の `process()` override は互換用途として維持

## 確認内容
本番相当環境で確認:
- `PROJECT_ROOT=/work`
- `runs/latest/nef/<date>/<date>_raw_exif_data.csv` を正常解決
- `/work/input/<year>/<date>` を正常解決
- `--max-images 3` 指定時に setup 前から件数制限が反映されることを確認
- 実際に 3 件のみ処理されることを確認

## 補足
現状の `max_images` は「対象データを事前に絞る」方式です。
そのため “途中停止→次回再開” の意味づけまでは今回の修正対象外です。