### PR TITLE
fix(portrait_quality): support strict resume-oriented max_images stop

### DIFF
--- a/src/photo_insight/pipelines/portrait_quality/portrait_quality_batch_processor.py
+++ b/src/photo_insight/pipelines/portrait_quality/portrait_quality_batch_processor.py
@@ -1,4 +1,3 @@
-# src/photo_insight/pipelines/portrait_quality/portrait_quality_batch_processor.py
 from __future__ import annotations
 
 import os
@@ -62,7 +61,7 @@ class PortraitQualityBatchProcessor(BaseBatchProcessor):
 
         self.memory_monitor = MemoryMonitor(self.logger)
         self.date = date
-        self.max_images = max_images  # ★ このrunで最大N枚だけ処理
+        self.max_images = max_images  # この run で最大 N 枚だけ処理（途中停止用）
 
         self.processed_images: set[str] = set()
         self.image_loader = ImageLoader(logger=self.logger)
@@ -92,31 +91,45 @@ class PortraitQualityBatchProcessor(BaseBatchProcessor):
 
         # --- Baseが拾う optional ---
         # self.stop_reason: Optional[str] = None
-        # self.processed_count_this_run: Optional[int] = None
+        self.processed_count_this_run: Optional[int] = None
 
     # ============================================================
-    # ★ run_batch 互換: Base.process(**kwargs) で渡される max_images を吸収
+    # run 条件の事前反映
     # ============================================================
     def execute(self, *args: Any, max_images: Optional[int] = None, **kwargs: Any) -> None:
         """
         setup() より前に run 固有条件を反映する。
-        max_images は load_data() に効かせたいので execute() で受ける。
+
+        - max_images は load_data(), after_data_loaded(), cleanup() に影響するため、
+        execute() で受けて先に self.max_images へ反映する。
+        - max_images 指定時は「途中停止 + resume」の厳密性を優先し、
+        Base 側の batch 並列実行も止めるため、この run に限って max_workers=1 に寄せる。
         """
         if max_images is not None:
             self.max_images = max_images
-        return super().execute(*args, **kwargs)
+
+        original_max_workers = self.max_workers
+        try:
+            if self.max_images is not None:
+                self.max_workers = 1
+                self.logger.info(
+                    f"max_images mode enabled. forcing single-worker execution for strict stop control "
+                    f"(max_images={self.max_images})."
+                )
+
+            return super().execute(*args, **kwargs)
+        finally:
+            self.max_workers = original_max_workers
 
     def process(self, *args: Any, max_images: Optional[int] = None, **kwargs: Any):
         """
+        互換用:
         BaseBatchProcessor.process() が受け取らない kwargs（例: max_images）を、
-        Processor 側で吸収して互換性を保つ。
+        Processor 側で吸収して破綻しないようにする。
 
-        - run_batch → execute(max_images=...) → Base.process(**kwargs) の経路で
-          TypeError が起きるのを防ぐ。
-        - 実際の制限は load_data() の self.max_images で実施する。
+        通常は execute() で run 条件を受ける。
         """
         if max_images is not None:
-            # ここでは「設定として受け取る」だけ。型/値の厳密チェックは load_data() で行う
             self.max_images = max_images
         return super().process(*args, **kwargs)
 
@@ -149,7 +162,6 @@ class PortraitQualityBatchProcessor(BaseBatchProcessor):
                 )
             self.memory_threshold_exceeded = True
 
-            # ★ Base(summary.json) にも stop理由を載せたいならここで決める
             if not getattr(self, "stop_reason", None):
                 self.stop_reason = "memory_threshold"
 
@@ -160,6 +172,39 @@ class PortraitQualityBatchProcessor(BaseBatchProcessor):
     def _stopping(self) -> bool:
         """stop状態（静かに即returnするための統一判定）"""
         return bool(self._stop_event.is_set() or getattr(self, "memory_threshold_exceeded", False))
+
+    def _should_stop_by_max_images(self) -> bool:
+        """
+        max_images による途中停止判定。
+        主目的は「途中停止 → 次回 resume」。
+        副用途として安全試験の少量実行にも使える。
+        """
+        if self.max_images is None:
+            return False
+
+        try:
+            limit = int(self.max_images)
+        except Exception as e:
+            raise ValueError(f"Invalid max_images: {self.max_images}") from e
+
+        if limit < 0:
+            raise ValueError(f"max_images must be >= 0. got: {limit}")
+
+        # 0 は「何もしない」
+        if limit == 0:
+            if not getattr(self, "stop_reason", None):
+                self.stop_reason = "max_images_limit"
+            self._stop_event.set()
+            return True
+
+        current = int(self.processed_count_this_run or 0)
+        if current >= limit:
+            if not getattr(self, "stop_reason", None):
+                self.stop_reason = "max_images_limit"
+            self._stop_event.set()
+            return True
+
+        return False
 
     # ============================================================
     # paths
@@ -193,12 +238,20 @@ class PortraitQualityBatchProcessor(BaseBatchProcessor):
 
     def _resolve_output_directory(self) -> Path:
         session = self._resolve_session_name()
-        use_run_dir = bool(getattr(self, "_persist_run_results", False)) and getattr(self, "run_ctx", None) is not None
-        if use_run_dir:
-            out_dir = Path(self.run_ctx.out_dir) / "artifacts" / "portrait_quality" / session
+
+        # max_images 指定時は、run をまたいで resume できるよう
+        # 固定ディレクトリ runs/latest/portrait_quality/<session> を使う
+        if self.max_images is not None:
+            out_dir = Path(self.project_root) / "runs" / "latest" / "portrait_quality" / session
         else:
-            base = self.config.get("output_directory", "temp")
-            out_dir = Path(self.project_root) / base / session
+            use_run_dir = (
+                bool(getattr(self, "_persist_run_results", False)) and getattr(self, "run_ctx", None) is not None
+            )
+            if use_run_dir:
+                out_dir = Path(self.run_ctx.out_dir) / "artifacts" / "portrait_quality" / session
+            else:
+                base = self.config.get("output_directory", "temp")
+                out_dir = Path(self.project_root) / base / session
 
         out_dir.mkdir(parents=True, exist_ok=True)
         return out_dir
@@ -209,14 +262,17 @@ class PortraitQualityBatchProcessor(BaseBatchProcessor):
     def setup(self) -> None:
         self.logger.info("Setting up PortraitQualityBatchProcessor...")
 
-        # ★ Stop flags (per-run)
+        # Stop flags (per-run)
         self._stop_event = Event()
         self.memory_threshold_exceeded = False
         self.completed_all_batches = False
 
-        # ★ per-run optional fields for Base summary
+        # per-run optional fields for Base summary
         self.stop_reason = None
-        self.processed_count_this_run = None
+        self.processed_count_this_run = 0
+
+        # max_images=0 は setup 後すぐ止められるようここでも許容
+        self._should_stop_by_max_images()
 
         # 1) 出力先を最初に確定（runs/artifacts or temp/...）
         out_dir = self._resolve_output_directory()
@@ -340,38 +396,31 @@ class PortraitQualityBatchProcessor(BaseBatchProcessor):
     def load_data(self) -> List[Dict[str, str]]:
         raw_data = self.load_image_data()
 
-        # まず未処理だけにする
+        # 未処理だけにする
         with self._processed_lock:
             todo = [d for d in raw_data if d.get("file_name") not in self.processed_images]
 
-        # ★この run で処理する最大枚数を制限（未処理だけを対象にする）
-        if self.max_images is not None:
-            try:
-                limit = int(self.max_images)
-            except Exception:
-                raise ValueError(f"Invalid max_images: {self.max_images}")
-
-            if limit < 0:
-                raise ValueError(f"max_images must be >= 0. got: {limit}")
-
-            # 0 は「何もしない」= 安全確認用途
-            if limit == 0:
-                return []
-
-            todo = todo[:limit]
-
+        # max_images はここでは絞り込まない
+        # 主目的は「途中停止→再開」なので、全未処理を対象として返す
         return todo
 
     # ============================================================
     # batch processing
     # ============================================================
     def _process_batch(self, batch: List[Dict[str, str]]) -> List[Dict[str, Any]]:
-        # ★ stop中は静かに即return（Baseが次バッチを呼んでもログスパムしない）
+        # stop中は静かに即return（Baseが次バッチを呼んでもログスパムしない）
         if self._stopping():
             return []
 
         # バッチ開始時点で止める（次バッチを出さない）
         if self._check_and_maybe_stop("batch_start"):
+            return []
+
+        if self._should_stop_by_max_images():
+            self.logger.info(
+                f"max_images limit reached before batch start "
+                f"({self.processed_count_this_run}/{self.max_images}). stopping."
+            )
             return []
 
         # 未処理画像のみ残す
@@ -383,7 +432,9 @@ class PortraitQualityBatchProcessor(BaseBatchProcessor):
             return []
 
         # 並列／直列処理
-        if (self.max_workers or 1) == 1:
+        # max_images 指定時は「途中停止＋resume」の厳密性を優先し、
+        # 先行 submit による超過実行を避けるため直列処理に寄せる。
+        if self.max_images is not None or (self.max_workers or 1) == 1:
             results = self._process_batch_serial(batch)
         else:
             results = self._process_batch_parallel(batch)
@@ -397,7 +448,7 @@ class PortraitQualityBatchProcessor(BaseBatchProcessor):
         self.memory_monitor.log_usage(prefix="Post batch GC")
         self._check_and_maybe_stop("batch_end")
 
-        # ★Baseに返すのはJSON安全なmini（results.jsonl事故を防ぐ）
+        # Baseに返すのはJSON安全なmini（results.jsonl事故を防ぐ）
         mini: List[Dict[str, Any]] = []
         for r in results or []:
             score = r.get("overall_score", None)
@@ -488,6 +539,9 @@ class PortraitQualityBatchProcessor(BaseBatchProcessor):
         if self._stop_event.is_set():
             return None
 
+        if self._should_stop_by_max_images():
+            return None
+
         try:
             if not self.base_directory:
                 raise RuntimeError("base_directory is not set")
@@ -500,6 +554,17 @@ class PortraitQualityBatchProcessor(BaseBatchProcessor):
             if result:
                 self.logger.info(f"Processed image: {img_info['file_name']}")
                 self._mark_as_processed(img_info["file_name"])
+
+                # この run で実際に処理した件数
+                self.processed_count_this_run = int(self.processed_count_this_run or 0) + 1
+
+                # 上限到達なら停止（結果は返して、この1件は有効とする）
+                if self._should_stop_by_max_images():
+                    self.logger.info(
+                        f"max_images limit reached "
+                        f"({self.processed_count_this_run}/{self.max_images}). stopping run."
+                    )
+
                 return result
         except Exception as e:
             self.logger.error(
@@ -514,6 +579,8 @@ class PortraitQualityBatchProcessor(BaseBatchProcessor):
             if self._stop_event.is_set():
                 break
             if self._check_and_maybe_stop("serial_loop"):
+                break
+            if self._should_stop_by_max_images():
                 break
 
             result = self._process_single_image(img_info)
@@ -531,6 +598,8 @@ class PortraitQualityBatchProcessor(BaseBatchProcessor):
                 if self._stop_event.is_set():
                     break
                 if self._check_and_maybe_stop("parallel_before_submit"):
+                    break
+                if self._should_stop_by_max_images():
                     break
                 futures.append(executor.submit(self._process_single_image, img_info))
 
@@ -589,7 +658,7 @@ class PortraitQualityBatchProcessor(BaseBatchProcessor):
                 for row in results_sorted:
                     writer.writerow({key: row.get(key, None) for key in fieldnames})
 
-                # ★ 途中停止でもCSVが壊れにくいように（追記運用の安定化）
+                # 途中停止でもCSVが壊れにくいように（追記運用の安定化）
                 csvfile.flush()
                 os.fsync(csvfile.fileno())
 
@@ -605,19 +674,18 @@ class PortraitQualityBatchProcessor(BaseBatchProcessor):
         if remaining_count < 0:
             remaining_count = 0
 
-        # ★ Baseが拾って summary.json に入れる（ドメイン上の“実処理数”はPQが定義）
+        # Baseが拾って summary.json に入れる（ドメイン上の“実処理数”はPQが定義）
         self.processed_count_this_run = int(processed_this_run)
 
-        # max_images で “意図的に止めた” 場合は stop_reason を付ける（次回再開前提のため）
-        if self.max_images is not None and not getattr(self, "memory_threshold_exceeded", False):
-            try:
-                limit = int(self.max_images)
-            except Exception:
-                limit = None
-            if limit is not None and limit > 0:
-                # 「処理対象を制限して走らせた」= 途中停止扱いが自然
-                if not getattr(self, "stop_reason", None) and not getattr(self, "completed_all_batches", False):
-                    self.stop_reason = "max_images_limit"
+        # max_images で意図的に止めた場合
+        if (
+            self.max_images is not None
+            and not getattr(self, "memory_threshold_exceeded", False)
+            and int(self.processed_count_this_run or 0) > 0
+            and int(self.processed_count_this_run or 0) < int(self._total_images_to_process or 0)
+        ):
+            if not getattr(self, "stop_reason", None):
+                self.stop_reason = "max_images_limit"
 
         if getattr(self, "memory_threshold_exceeded", False):
             if not getattr(self, "stop_reason", None):
@@ -628,14 +696,21 @@ class PortraitQualityBatchProcessor(BaseBatchProcessor):
                 f"Processed {processed_this_run} images, {remaining_count} remaining. "
                 "You can re-run to continue remaining images."
             )
+        elif getattr(self, "stop_reason", None) == "max_images_limit":
+            self.logger.info(
+                f"Batch processing stopped by max_images. "
+                f"Processed {processed_this_run} images, {remaining_count} remaining. "
+                "You can re-run to continue remaining images."
+            )
         elif getattr(self, "completed_all_batches", False):
             self.logger.info(f"All batches processed successfully. Total processed images: {processed_this_run}")
 
-        # ★重要: stopした場合は processed_images_file を消さない（再開に必要）
+        # 重要: stopした場合は processed_images_file を消さない（再開に必要）
         processed_file = getattr(self, "processed_images_file", None)
         if (
             getattr(self, "completed_all_batches", False)
             and not getattr(self, "memory_threshold_exceeded", False)
+            and getattr(self, "stop_reason", None) is None
             and processed_file
             and os.path.exists(processed_file)
         ):


### PR DESCRIPTION
## 概要
PortraitQualityBatchProcessor の max_images を、
途中停止 + resume 前提で厳密に動作するよう修正しました。

## 対応内容
- execute() で run 条件を setup 前に反映
- max_images 指定時は strict stop control のため single-worker に強制
- load_data() では事前絞り込みせず、実処理中に max_images で停止
- max_images 時の出力先を runs/latest/portrait_quality/<session> に固定
- processed_images と evaluation_results を run をまたいで再利用可能にした
- 途中停止時は processed_images_file を削除しない

## 確認内容
- 1回目の --max-images 3 で 3件のみ処理
- processed_images_*.txt が 3行で残る
- 2回目の --max-images 3 で previously processed images を読んで続きから再開
- 2回目開始時に 407 件へ減っていることを確認
- strict stop / fixed output dir / resume behavior を確認

## 補足
特定NEFファイル（例: DSC_7482.NEF）で native crash（exit code 139）が発生する runtime stability issue は別課題です。
本PRの対象は max_images と resume の制御・保存先設計です。