### PR TITLE
feat(cli): persist pipeline summary as JSON artifact

### DIFF
--- a/src/photo_insight/cli/run_batch.py
+++ b/src/photo_insight/cli/run_batch.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import ast
 import importlib
+import json
 import re
 import sys
 from pathlib import Path
@@ -474,6 +475,28 @@ def _infer_processed_count(proc: BaseBatchProcessor) -> Optional[int]:
     return None
 
 
+def _infer_run_output_dir(proc: BaseBatchProcessor) -> Optional[str]:
+    """
+    processor インスタンスから run 出力ディレクトリを推定する。
+
+    Parameters
+    ----------
+    proc : BaseBatchProcessor
+        実行済み processor インスタンス。
+
+    Returns
+    -------
+    Optional[str]
+        run 出力ディレクトリ。解決できない場合は None。
+    """
+    run_ctx = getattr(proc, "run_ctx", None)
+    if run_ctx is not None and getattr(run_ctx, "out_dir", None):
+        return str(Path(run_ctx.out_dir))
+
+    project_root = Path(getattr(proc, "project_root", Path.cwd()))
+    return str(project_root / "runs" / "latest")
+
+
 def _build_stage_result(
     processor_spec: str,
     proc: BaseBatchProcessor,
@@ -512,6 +535,7 @@ def _build_stage_result(
         "processed_count": None,
         "applied_max_images": None,
         "message": None,
+        "run_output_dir": _infer_run_output_dir(proc),
     }
 
     if exec_kwargs is not None:
@@ -528,9 +552,51 @@ def _build_stage_result(
     return result
 
 
+def _build_pipeline_run_context(
+    ctor_kwargs: Dict[str, Any],
+    exec_kwargs: Dict[str, Any],
+    injected: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    pipeline summary 用の runtime context を構築する。
+
+    Parameters
+    ----------
+    ctor_kwargs : Dict[str, Any]
+        processor コンストラクタ引数。
+
+    exec_kwargs : Dict[str, Any]
+        pipeline 共通 execute kwargs。
+
+    injected : Dict[str, Any]
+        runtime override 情報。
+
+    Returns
+    -------
+    Dict[str, Any]
+        pipeline runtime context。
+    """
+    config_paths = ctor_kwargs.get("config_paths")
+    if isinstance(config_paths, tuple):
+        config_paths = list(config_paths)
+
+    return {
+        "date": injected.get("date"),
+        "target_dir": injected.get("target_dir"),
+        "config_path": ctor_kwargs.get("config_path"),
+        "max_workers": ctor_kwargs.get("max_workers"),
+        "max_images": exec_kwargs.get("max_images"),
+        "config_env": ctor_kwargs.get("config_env"),
+        "config_paths": config_paths,
+    }
+
+
 def _build_pipeline_summary(
     stages: List[str],
     stage_results: List[Dict[str, Any]],
+    ctor_kwargs: Dict[str, Any],
+    exec_kwargs: Dict[str, Any],
+    injected: Dict[str, Any],
 ) -> Dict[str, Any]:
     """
     pipeline 実行結果から summary を構築する。
@@ -543,16 +609,78 @@ def _build_pipeline_summary(
     stage_results : List[Dict[str, Any]]
         各 stage の実行結果。
 
+    ctor_kwargs : Dict[str, Any]
+        processor コンストラクタ引数。
+
+    exec_kwargs : Dict[str, Any]
+        pipeline 共通 execute kwargs。
+
+    injected : Dict[str, Any]
+        runtime override 情報。
+
     Returns
     -------
     Dict[str, Any]
         pipeline summary。
     """
     return {
+        "summary_version": 1,
         "pipeline": stages,
         "status": "success",
+        "run_context": _build_pipeline_run_context(
+            ctor_kwargs=ctor_kwargs,
+            exec_kwargs=exec_kwargs,
+            injected=injected,
+        ),
         "stages": stage_results,
     }
+
+
+def _resolve_pipeline_summary_output_path(summary: Dict[str, Any]) -> Path:
+    """
+    pipeline summary の出力先パスを解決する。
+
+    Parameters
+    ----------
+    summary : Dict[str, Any]
+        pipeline summary。
+
+    Returns
+    -------
+    Path
+        pipeline_summary.json の出力先パス。
+    """
+    stages = summary.get("stages", [])
+    if stages:
+        first_run_output_dir = stages[0].get("run_output_dir")
+        if first_run_output_dir:
+            return Path(first_run_output_dir) / "pipeline_summary.json"
+
+    cwd_runs_latest = Path.cwd() / "runs" / "latest"
+    return cwd_runs_latest / "pipeline_summary.json"
+
+
+def _write_pipeline_summary_json(summary: Dict[str, Any]) -> Path:
+    """
+    pipeline summary を JSON ファイルとして保存する。
+
+    Parameters
+    ----------
+    summary : Dict[str, Any]
+        保存対象の pipeline summary。
+
+    Returns
+    -------
+    Path
+        保存先パス。
+    """
+    output_path = _resolve_pipeline_summary_output_path(summary)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return output_path
 
 
 def _print_pipeline_summary(summary: Dict[str, Any]) -> None:
@@ -567,6 +695,15 @@ def _print_pipeline_summary(summary: Dict[str, Any]) -> None:
     print("[pipeline summary]")
     print(f"pipeline = {','.join(summary['pipeline'])}")
     print(f"status = {summary['status']}")
+
+    run_context = summary.get("run_context")
+    if run_context:
+        if run_context.get("date") is not None:
+            print(f"date = {run_context['date']}")
+        if run_context.get("target_dir") is not None:
+            print(f"target_dir = {run_context['target_dir']}")
+        if run_context.get("max_images") is not None:
+            print(f"max_images = {run_context['max_images']}")
 
     for stage in summary["stages"]:
         print(f"[stage] {stage['name']}")
@@ -662,13 +799,14 @@ def run_pipeline_chain(
 
     Notes
     -----
-    PR4 では以下を扱う。
+    PR5 では以下を扱う。
 
     - stage result の収集
     - pipeline summary の生成
     - max_images の pipeline 対応
       - 先頭 stage のみに適用
       - 後続 stage は upstream artifact に従う
+    - pipeline summary JSON 永続化のための run_context / run_output_dir 付与
     """
     previous_result: Optional[Dict[str, Any]] = None
     stage_results: List[Dict[str, Any]] = []
@@ -699,7 +837,13 @@ def run_pipeline_chain(
         )
         stage_results.append(previous_result)
 
-    return _build_pipeline_summary(stages=stages, stage_results=stage_results)
+    return _build_pipeline_summary(
+        stages=stages,
+        stage_results=stage_results,
+        ctor_kwargs=ctor_kwargs,
+        exec_kwargs=exec_kwargs,
+        injected=injected,
+    )
 
 
 # -------------------------
@@ -876,6 +1020,8 @@ def main(argv: Optional[list[str]] = None) -> int:
             injected=injected,
         )
         _print_pipeline_summary(summary)
+        summary_path = _write_pipeline_summary_json(summary)
+        print(f"pipeline_summary_json = {summary_path}")
         return 0
 
     assert args.processor is not None

--- a/tests/unit/cli/test_run_batch_pipeline_pr2.py
+++ b/tests/unit/cli/test_run_batch_pipeline_pr2.py
@@ -112,6 +112,7 @@ def test_run_pipeline_chain_executes_stages_in_order(
                 "processed_count": None,
                 "applied_max_images": None,
                 "message": None,
+                "run_output_dir": "/tmp/project/runs/latest",
             }
 
         return {
@@ -122,6 +123,7 @@ def test_run_pipeline_chain_executes_stages_in_order(
             "processed_count": None,
             "applied_max_images": None,
             "message": None,
+            "run_output_dir": "/tmp/project/runs/latest",
         }
 
     monkeypatch.setattr(run_batch, "run_single_processor", fake_run_single_processor)
@@ -143,30 +145,40 @@ def test_run_pipeline_chain_executes_stages_in_order(
         "input_csv_path": "/work/runs/latest/nef/2026-02-17/2026-02-17_raw_exif_data.csv",
     }
 
-    assert summary == {
-        "pipeline": ["nef", "portrait_quality"],
-        "status": "success",
-        "stages": [
-            {
-                "name": "nef",
-                "status": "success",
-                "input_csv_path": None,
-                "output_csv_path": "/work/runs/latest/nef/2026-02-17/2026-02-17_raw_exif_data.csv",
-                "processed_count": None,
-                "applied_max_images": None,
-                "message": None,
-            },
-            {
-                "name": "portrait_quality",
-                "status": "success",
-                "input_csv_path": "/work/runs/latest/nef/2026-02-17/2026-02-17_raw_exif_data.csv",
-                "output_csv_path": None,
-                "processed_count": None,
-                "applied_max_images": None,
-                "message": None,
-            },
-        ],
+    assert summary["summary_version"] == 1
+    assert summary["pipeline"] == ["nef", "portrait_quality"]
+    assert summary["status"] == "success"
+    assert summary["run_context"] == {
+        "date": "2026-02-17",
+        "target_dir": None,
+        "config_path": "config/config.prod.yaml",
+        "max_workers": 2,
+        "max_images": None,
+        "config_env": None,
+        "config_paths": None,
     }
+    assert summary["stages"] == [
+        {
+            "name": "nef",
+            "status": "success",
+            "input_csv_path": None,
+            "output_csv_path": "/work/runs/latest/nef/2026-02-17/2026-02-17_raw_exif_data.csv",
+            "processed_count": None,
+            "applied_max_images": None,
+            "message": None,
+            "run_output_dir": "/tmp/project/runs/latest",
+        },
+        {
+            "name": "portrait_quality",
+            "status": "success",
+            "input_csv_path": "/work/runs/latest/nef/2026-02-17/2026-02-17_raw_exif_data.csv",
+            "output_csv_path": None,
+            "processed_count": None,
+            "applied_max_images": None,
+            "message": None,
+            "run_output_dir": "/tmp/project/runs/latest",
+        },
+    ]
 
 
 def test_main_pipeline_execution_calls_run_pipeline_chain(

--- a/tests/unit/cli/test_run_batch_pipeline_pr3.py
+++ b/tests/unit/cli/test_run_batch_pipeline_pr3.py
@@ -90,7 +90,7 @@ def test_build_stage_result_for_nef_includes_output_csv_path(
     )
 
     class DummyProc:
-        pass
+        project_root = "/tmp/project"
 
     result = run_batch._build_stage_result(
         processor_spec="nef",
@@ -98,20 +98,19 @@ def test_build_stage_result_for_nef_includes_output_csv_path(
         injected={"date": "2026-02-17"},
     )
 
-    assert result == {
-        "name": "nef",
-        "status": "success",
-        "input_csv_path": None,
-        "output_csv_path": expected,
-        "processed_count": None,
-        "applied_max_images": None,
-        "message": None,
-    }
+    assert result["name"] == "nef"
+    assert result["status"] == "success"
+    assert result["input_csv_path"] is None
+    assert result["output_csv_path"] == expected
+    assert result["processed_count"] is None
+    assert result["applied_max_images"] is None
+    assert result["message"] is None
+    assert result["run_output_dir"] == "/tmp/project/runs/latest"
 
 
 def test_build_stage_result_for_portrait_quality_has_minimum_fields() -> None:
     class DummyProc:
-        pass
+        project_root = "/tmp/project"
 
     result = run_batch._build_stage_result(
         processor_spec="portrait_quality",
@@ -119,15 +118,14 @@ def test_build_stage_result_for_portrait_quality_has_minimum_fields() -> None:
         injected={"date": "2026-02-17"},
     )
 
-    assert result == {
-        "name": "portrait_quality",
-        "status": "success",
-        "input_csv_path": None,
-        "output_csv_path": None,
-        "processed_count": None,
-        "applied_max_images": None,
-        "message": None,
-    }
+    assert result["name"] == "portrait_quality"
+    assert result["status"] == "success"
+    assert result["input_csv_path"] is None
+    assert result["output_csv_path"] is None
+    assert result["processed_count"] is None
+    assert result["applied_max_images"] is None
+    assert result["message"] is None
+    assert result["run_output_dir"] == "/tmp/project/runs/latest"
 
 
 def test_run_pipeline_chain_passes_nef_csv_to_portrait_quality(

--- a/tests/unit/cli/test_run_batch_pipeline_pr4.py
+++ b/tests/unit/cli/test_run_batch_pipeline_pr4.py
@@ -52,7 +52,11 @@ def test_build_stage_result_for_nef_returns_pr4_extended_fields(
         lambda proc, injected: expected_csv,
     )
 
-    proc = DummyNEFProcessor()
+    class DummyNEFProc:
+        processed_count = 5
+        project_root = "/tmp/project"
+
+    proc = DummyNEFProc()
 
     result = run_batch._build_stage_result(
         processor_spec="nef",
@@ -61,20 +65,20 @@ def test_build_stage_result_for_nef_returns_pr4_extended_fields(
         exec_kwargs={"max_images": 5},
     )
 
-    assert result == {
-        "name": "nef",
-        "status": "success",
-        "input_csv_path": None,
-        "output_csv_path": expected_csv,
-        "processed_count": 5,
-        "applied_max_images": 5,
-        "message": None,
-    }
+    assert result["name"] == "nef"
+    assert result["status"] == "success"
+    assert result["input_csv_path"] is None
+    assert result["output_csv_path"] == expected_csv
+    assert result["processed_count"] == 5
+    assert result["applied_max_images"] == 5
+    assert result["message"] is None
+    assert result["run_output_dir"] == "/tmp/project/runs/latest"
 
 
 def test_build_stage_result_for_portrait_quality_returns_pr4_extended_fields() -> None:
     class DummyPortraitProc:
         processed_count = 5
+        project_root = "/tmp/project"
 
     result = run_batch._build_stage_result(
         processor_spec="portrait_quality",
@@ -85,15 +89,14 @@ def test_build_stage_result_for_portrait_quality_returns_pr4_extended_fields() -
         },
     )
 
-    assert result == {
-        "name": "portrait_quality",
-        "status": "success",
-        "input_csv_path": "/work/runs/latest/nef/2026-02-17/2026-02-17_raw_exif_data.csv",
-        "output_csv_path": None,
-        "processed_count": 5,
-        "applied_max_images": None,
-        "message": None,
-    }
+    assert result["name"] == "portrait_quality"
+    assert result["status"] == "success"
+    assert result["input_csv_path"] == "/work/runs/latest/nef/2026-02-17/2026-02-17_raw_exif_data.csv"
+    assert result["output_csv_path"] is None
+    assert result["processed_count"] == 5
+    assert result["applied_max_images"] is None
+    assert result["message"] is None
+    assert result["run_output_dir"] == "/tmp/project/runs/latest"
 
 
 def test_run_pipeline_chain_returns_summary_and_applies_max_images_only_to_first_stage(

--- a/tests/unit/cli/test_run_batch_pipeline_pr5.py
+++ b/tests/unit/cli/test_run_batch_pipeline_pr5.py
@@ -1,0 +1,481 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from photo_insight.cli import run_batch
+
+
+class DummyProcessor:
+    def __init__(self, **kwargs: Any) -> None:
+        self.ctor_kwargs = kwargs
+        self.execute_calls: List[Dict[str, Any]] = []
+        self.project_root = Path("/tmp/project")
+        self.run_ctx = None
+
+    def execute(self, **kwargs: Any) -> None:
+        self.execute_calls.append(dict(kwargs))
+
+
+class DummyNEFProcessor(DummyProcessor):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.processed_count = 5
+        self.run_ctx = type("RunCtx", (), {"out_dir": "/tmp/project/runs/2026-03-13/run_001"})()
+
+
+class DummyPortraitProcessor(DummyProcessor):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.processed_count = 5
+        self.run_ctx = type("RunCtx", (), {"out_dir": "/tmp/project/runs/2026-03-13/run_001"})()
+
+
+@pytest.fixture
+def ctor_kwargs() -> Dict[str, Any]:
+    return {
+        "config_path": "config/config.prod.yaml",
+        "max_workers": 2,
+        "config_env": None,
+    }
+
+
+@pytest.fixture
+def injected() -> Dict[str, Any]:
+    return {
+        "date": "2026-02-17",
+    }
+
+
+def test_infer_run_output_dir_prefers_run_ctx_out_dir() -> None:
+    proc = DummyNEFProcessor()
+    result = run_batch._infer_run_output_dir(proc)
+    assert result == "/tmp/project/runs/2026-03-13/run_001"
+
+
+def test_infer_run_output_dir_falls_back_to_project_root_runs_latest() -> None:
+    proc = DummyProcessor()
+    result = run_batch._infer_run_output_dir(proc)
+    assert result == "/tmp/project/runs/latest"
+
+
+def test_build_stage_result_includes_run_output_dir_for_nef(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected_csv = "/tmp/project/runs/2026-03-13/run_001/artifacts/nef/2026-02-17/2026-02-17_raw_exif_data.csv"
+    proc = DummyNEFProcessor()
+
+    monkeypatch.setattr(
+        run_batch,
+        "_infer_nef_output_csv_path",
+        lambda proc, injected: expected_csv,
+    )
+
+    result = run_batch._build_stage_result(
+        processor_spec="nef",
+        proc=proc,
+        injected={"date": "2026-02-17"},
+        exec_kwargs={"max_images": 5},
+    )
+
+    assert result == {
+        "name": "nef",
+        "status": "success",
+        "input_csv_path": None,
+        "output_csv_path": expected_csv,
+        "processed_count": 5,
+        "applied_max_images": 5,
+        "message": None,
+        "run_output_dir": "/tmp/project/runs/2026-03-13/run_001",
+    }
+
+
+def test_build_pipeline_run_context_returns_expected_fields(
+    ctor_kwargs: Dict[str, Any],
+    injected: Dict[str, Any],
+) -> None:
+    result = run_batch._build_pipeline_run_context(
+        ctor_kwargs=ctor_kwargs,
+        exec_kwargs={"max_images": 10, "append_mode": True},
+        injected=injected,
+    )
+
+    assert result == {
+        "date": "2026-02-17",
+        "target_dir": None,
+        "config_path": "config/config.prod.yaml",
+        "max_workers": 2,
+        "max_images": 10,
+        "config_env": None,
+        "config_paths": None,
+    }
+
+
+def test_build_pipeline_summary_includes_summary_version_and_run_context(
+    ctor_kwargs: Dict[str, Any],
+    injected: Dict[str, Any],
+) -> None:
+    stage_results = [
+        {
+            "name": "nef",
+            "status": "success",
+            "input_csv_path": None,
+            "output_csv_path": "/tmp/project/runs/2026-03-13/run_001/artifacts/nef/2026-02-17/2026-02-17_raw_exif_data.csv",
+            "processed_count": 5,
+            "applied_max_images": 5,
+            "message": None,
+            "run_output_dir": "/tmp/project/runs/2026-03-13/run_001",
+        },
+        {
+            "name": "portrait_quality",
+            "status": "success",
+            "input_csv_path": "/tmp/project/runs/2026-03-13/run_001/artifacts/nef/2026-02-17/2026-02-17_raw_exif_data.csv",
+            "output_csv_path": None,
+            "processed_count": 5,
+            "applied_max_images": None,
+            "message": None,
+            "run_output_dir": "/tmp/project/runs/2026-03-13/run_001",
+        },
+    ]
+
+    summary = run_batch._build_pipeline_summary(
+        stages=["nef", "portrait_quality"],
+        stage_results=stage_results,
+        ctor_kwargs=ctor_kwargs,
+        exec_kwargs={"max_images": 5},
+        injected=injected,
+    )
+
+    assert summary == {
+        "summary_version": 1,
+        "pipeline": ["nef", "portrait_quality"],
+        "status": "success",
+        "run_context": {
+            "date": "2026-02-17",
+            "target_dir": None,
+            "config_path": "config/config.prod.yaml",
+            "max_workers": 2,
+            "max_images": 5,
+            "config_env": None,
+            "config_paths": None,
+        },
+        "stages": stage_results,
+    }
+
+
+def test_resolve_pipeline_summary_output_path_uses_first_stage_run_output_dir() -> None:
+    summary = {
+        "summary_version": 1,
+        "pipeline": ["nef", "portrait_quality"],
+        "status": "success",
+        "run_context": {},
+        "stages": [
+            {
+                "name": "nef",
+                "run_output_dir": "/tmp/project/runs/2026-03-13/run_001",
+            },
+            {
+                "name": "portrait_quality",
+                "run_output_dir": "/tmp/project/runs/2026-03-13/run_001",
+            },
+        ],
+    }
+
+    path = run_batch._resolve_pipeline_summary_output_path(summary)
+    assert path == Path("/tmp/project/runs/2026-03-13/run_001/pipeline_summary.json")
+
+
+def test_write_pipeline_summary_json_writes_expected_content(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    output_path = tmp_path / "runs" / "2026-03-13" / "run_001" / "pipeline_summary.json"
+    summary = {
+        "summary_version": 1,
+        "pipeline": ["nef", "portrait_quality"],
+        "status": "success",
+        "run_context": {
+            "date": "2026-02-17",
+            "target_dir": None,
+            "config_path": "config/config.prod.yaml",
+            "max_workers": 2,
+            "max_images": 5,
+            "config_env": None,
+            "config_paths": None,
+        },
+        "stages": [
+            {
+                "name": "nef",
+                "status": "success",
+                "input_csv_path": None,
+                "output_csv_path": "/tmp/project/runs/2026-03-13/run_001/artifacts/nef/2026-02-17/2026-02-17_raw_exif_data.csv",
+                "processed_count": 5,
+                "applied_max_images": 5,
+                "message": None,
+                "run_output_dir": str(tmp_path / "runs" / "2026-03-13" / "run_001"),
+            }
+        ],
+    }
+
+    monkeypatch.setattr(
+        run_batch,
+        "_resolve_pipeline_summary_output_path",
+        lambda summary: output_path,
+    )
+
+    saved_path = run_batch._write_pipeline_summary_json(summary)
+
+    assert saved_path == output_path
+    assert output_path.exists()
+
+    loaded = json.loads(output_path.read_text(encoding="utf-8"))
+    assert loaded == summary
+
+
+def test_run_pipeline_chain_returns_summary_with_run_context_and_run_output_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    ctor_kwargs: Dict[str, Any],
+    injected: Dict[str, Any],
+) -> None:
+    calls: List[Dict[str, Any]] = []
+
+    def fake_run_single_processor(
+        processor_spec: str,
+        ctor_kwargs: Dict[str, Any],
+        exec_kwargs: Dict[str, Any],
+        injected: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        calls.append(
+            {
+                "processor_spec": processor_spec,
+                "ctor_kwargs": dict(ctor_kwargs),
+                "exec_kwargs": dict(exec_kwargs),
+                "injected": dict(injected),
+            }
+        )
+
+        if processor_spec == "nef":
+            return {
+                "name": "nef",
+                "status": "success",
+                "input_csv_path": None,
+                "output_csv_path": "/tmp/project/runs/2026-03-13/run_001/artifacts/nef/2026-02-17/2026-02-17_raw_exif_data.csv",
+                "processed_count": 5,
+                "applied_max_images": exec_kwargs.get("max_images"),
+                "message": None,
+                "run_output_dir": "/tmp/project/runs/2026-03-13/run_001",
+            }
+
+        if processor_spec == "portrait_quality":
+            return {
+                "name": "portrait_quality",
+                "status": "success",
+                "input_csv_path": exec_kwargs.get("input_csv_path"),
+                "output_csv_path": None,
+                "processed_count": 5,
+                "applied_max_images": exec_kwargs.get("max_images"),
+                "message": None,
+                "run_output_dir": "/tmp/project/runs/2026-03-13/run_001",
+            }
+
+        raise AssertionError(f"unexpected processor: {processor_spec}")
+
+    monkeypatch.setattr(run_batch, "run_single_processor", fake_run_single_processor)
+
+    summary = run_batch.run_pipeline_chain(
+        stages=["nef", "portrait_quality"],
+        ctor_kwargs=ctor_kwargs,
+        exec_kwargs={"append_mode": True, "max_images": 5},
+        injected=injected,
+    )
+
+    assert summary["summary_version"] == 1
+    assert summary["pipeline"] == ["nef", "portrait_quality"]
+    assert summary["status"] == "success"
+    assert summary["run_context"] == {
+        "date": "2026-02-17",
+        "target_dir": None,
+        "config_path": "config/config.prod.yaml",
+        "max_workers": 2,
+        "max_images": 5,
+        "config_env": None,
+        "config_paths": None,
+    }
+
+    assert [x["processor_spec"] for x in calls] == ["nef", "portrait_quality"]
+    assert calls[0]["exec_kwargs"] == {
+        "append_mode": True,
+        "max_images": 5,
+    }
+    assert calls[1]["exec_kwargs"] == {
+        "append_mode": True,
+        "input_csv_path": "/tmp/project/runs/2026-03-13/run_001/artifacts/nef/2026-02-17/2026-02-17_raw_exif_data.csv",
+    }
+
+    assert summary["stages"][0]["run_output_dir"] == "/tmp/project/runs/2026-03-13/run_001"
+    assert summary["stages"][1]["run_output_dir"] == "/tmp/project/runs/2026-03-13/run_001"
+
+
+def test_print_pipeline_summary_includes_run_context_lines(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    summary = {
+        "summary_version": 1,
+        "pipeline": ["nef", "portrait_quality"],
+        "status": "success",
+        "run_context": {
+            "date": "2026-02-17",
+            "target_dir": "/work/input/2026-02-17",
+            "config_path": "config/config.prod.yaml",
+            "max_workers": 2,
+            "max_images": 5,
+            "config_env": None,
+            "config_paths": None,
+        },
+        "stages": [
+            {
+                "name": "nef",
+                "status": "success",
+                "input_csv_path": None,
+                "output_csv_path": "/tmp/project/runs/2026-03-13/run_001/artifacts/nef/2026-02-17/2026-02-17_raw_exif_data.csv",
+                "processed_count": 5,
+                "applied_max_images": 5,
+                "message": None,
+                "run_output_dir": "/tmp/project/runs/2026-03-13/run_001",
+            }
+        ],
+    }
+
+    run_batch._print_pipeline_summary(summary)
+    captured = capsys.readouterr()
+
+    assert "[pipeline summary]" in captured.out
+    assert "pipeline = nef,portrait_quality" in captured.out
+    assert "status = success" in captured.out
+    assert "date = 2026-02-17" in captured.out
+    assert "target_dir = /work/input/2026-02-17" in captured.out
+    assert "max_images = 5" in captured.out
+    assert "[stage] nef" in captured.out
+
+
+def test_main_pipeline_writes_summary_json_and_returns_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    printed: List[Dict[str, Any]] = []
+    saved: List[Dict[str, Any]] = []
+
+    monkeypatch.setattr(
+        run_batch,
+        "run_pipeline_chain",
+        lambda stages, ctor_kwargs, exec_kwargs, injected: {
+            "summary_version": 1,
+            "pipeline": stages,
+            "status": "success",
+            "run_context": {
+                "date": "2026-02-17",
+                "target_dir": None,
+                "config_path": "config/config.prod.yaml",
+                "max_workers": 2,
+                "max_images": 5,
+                "config_env": None,
+                "config_paths": None,
+            },
+            "stages": [
+                {
+                    "name": "nef",
+                    "status": "success",
+                    "input_csv_path": None,
+                    "output_csv_path": "/tmp/project/runs/2026-03-13/run_001/artifacts/nef/2026-02-17/2026-02-17_raw_exif_data.csv",
+                    "processed_count": 5,
+                    "applied_max_images": 5,
+                    "message": None,
+                    "run_output_dir": "/tmp/project/runs/2026-03-13/run_001",
+                },
+                {
+                    "name": "portrait_quality",
+                    "status": "success",
+                    "input_csv_path": "/tmp/project/runs/2026-03-13/run_001/artifacts/nef/2026-02-17/2026-02-17_raw_exif_data.csv",
+                    "output_csv_path": None,
+                    "processed_count": 5,
+                    "applied_max_images": None,
+                    "message": None,
+                    "run_output_dir": "/tmp/project/runs/2026-03-13/run_001",
+                },
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        run_batch,
+        "_print_pipeline_summary",
+        lambda summary: printed.append(summary),
+    )
+    monkeypatch.setattr(
+        run_batch,
+        "_write_pipeline_summary_json",
+        lambda summary: saved.append(summary) or Path("/tmp/project/runs/2026-03-13/run_001/pipeline_summary.json"),
+    )
+
+    rc = run_batch.main(
+        [
+            "--pipeline",
+            "nef,portrait_quality",
+            "--config",
+            "config/config.prod.yaml",
+            "--max-images",
+            "5",
+            "--date",
+            "2026-02-17",
+        ]
+    )
+
+    assert rc == 0
+    assert len(printed) == 1
+    assert len(saved) == 1
+    assert printed[0]["summary_version"] == 1
+    assert saved[0]["pipeline"] == ["nef", "portrait_quality"]
+
+
+def test_main_pipeline_dry_run_does_not_write_summary_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = {"run_pipeline_chain": 0, "print_summary": 0, "write_json": 0}
+
+    monkeypatch.setattr(
+        run_batch,
+        "run_pipeline_chain",
+        lambda stages, ctor_kwargs, exec_kwargs, injected: called.__setitem__(
+            "run_pipeline_chain", called["run_pipeline_chain"] + 1
+        ),
+    )
+    monkeypatch.setattr(
+        run_batch,
+        "_print_pipeline_summary",
+        lambda summary: called.__setitem__("print_summary", called["print_summary"] + 1),
+    )
+    monkeypatch.setattr(
+        run_batch,
+        "_write_pipeline_summary_json",
+        lambda summary: called.__setitem__("write_json", called["write_json"] + 1),
+    )
+
+    rc = run_batch.main(
+        [
+            "--pipeline",
+            "nef,portrait_quality",
+            "--config",
+            "config/config.prod.yaml",
+            "--max-images",
+            "5",
+            "--date",
+            "2026-02-17",
+            "--dry-run",
+        ]
+    )
+
+    assert rc == 0
+    assert called["run_pipeline_chain"] == 0
+    assert called["print_summary"] == 0
+    assert called["write_json"] == 0


### PR DESCRIPTION
PR概要

本PRでは run_batch CLI の pipeline 実行結果を JSON 形式で保存する機能を追加しました。

PR4 で追加された pipeline summary（標準出力） に加え、
実行結果を pipeline_summary.json として保存することで、

実行履歴の追跡

後続処理での利用

運用監査

再実行判断

を可能にします。