### PR TITLE
fix: allow xmp_export to write xmp files in prod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,8 +65,8 @@ out*/
 # =========================
 # Runs (結論: 対象外でOK → ignore 推奨)
 # =========================
-Runs/
-runs/
+/Runs/
+/runs/
 
 # =========================
 # Conda / lock
@@ -169,3 +169,6 @@ pip_freeze*.json
 # =========================
 .build_config/
 models/
+
+# runtime input data
+/input/

--- a/deploy/prod/compose.prod.yaml
+++ b/deploy/prod/compose.prod.yaml
@@ -16,8 +16,8 @@ services:
       MPLCONFIGDIR: /work/tmp/matplotlib
 
     volumes:
-      # 入力（NASやローカル写真）
-      - ${PHOTO_INSIGHT_INPUT_DIR:-/mnt/l/picture}:/work/input:ro
+      # 入力写真 + XMP書き込み先
+      - ${PHOTO_INSIGHT_INPUT_DIR:-/mnt/l/picture}:/work/input
 
       # 実行結果・ログ（すべて prod 配下）
       - ./runs:/work/runs


### PR DESCRIPTION
## Summary

* update `compose.prod.yaml`
* change `/work/input` mount from read-only to read-write
* allow `xmp_export` to create/update `.xmp` files next to NEF files in prod

## Background

* `xmp_export` writes `.xmp` files beside source NEF files
* prod input mount was `:ro`, which caused `Read-only file system` errors

## Verification

* `docker compose -f compose.prod.yaml config`
* confirmed previous prod failure was caused by read-only `/work/input`
