### PR TITLE
Fix: Green判定の再定義 (#322)

### DIFF
--- a/docs/design/green_decision_redefinition.md
+++ b/docs/design/green_decision_redefinition.md
@@ -1,0 +1,384 @@
+# Green判定の再定義
+
+- Issue: #317 [2026-0030] Green判定の再定義（最低成立＋残す理由）
+- Status: Implemented
+- Updated: 2026-04-14
+
+## 1. 目的
+
+Green判定を、単なる閾値通過ではなく、次の意味に再定義する。
+
+**Green = 最低成立を満たし、残す理由が1つ以上ある**
+
+これにより、Green の意味を「成立していて、残す根拠がある写真」に揃える。
+
+---
+
+## 2. 背景
+
+従来の Green 判定では、次の問題が起きうる。
+
+- Green だが残す理由が弱い写真が混ざる
+- ピンボケや成立不足が Green に入る余地がある
+- なぜ Green になったか説明しづらい
+- 閾値調整や見直しのときに根拠を追いにくい
+
+このため、Green を単一の総合点や既存 accepted 系フラグと同一視せず、独立した品質判定として定義し直した。
+
+---
+
+## 3. 方針
+
+Green 判定は2段階で行う。
+
+### 3.1 最低成立
+候補として残してよい最低ラインを満たしていること。
+
+実装では、実データを踏まえて以下を最低成立に採用した。
+
+- `shot_type != "no_face"`
+- `face_detected == True`
+- `blurriness_score >= min_blurriness_score`
+- `composition_score >= min_composition_score`
+- 顔が検出されている場合は `face_exposure_score >= min_face_exposure_score`
+
+### 3.2 残す理由
+その写真を積極的に残す理由があること。
+
+実装では、以下の3軸で keep reason を収集する。
+
+- SNS受け
+- モデル受け
+- プロ品質
+
+---
+
+## 4. 判定ルール
+
+最終判定は以下とする。
+
+```text
+is_green = minimum_pass and keep_reasons が1件以上
+```
+
+### 4.1 最低成立NG
+以下のどれかを満たさない場合は Green にしない。
+
+- `shot_type == "no_face"`
+- `face_detected == False`
+- `blurriness_score < min_blurriness_score`
+- `composition_score < min_composition_score`
+- 顔あり画像で `face_exposure_score < min_face_exposure_score`
+
+### 4.2 最低成立OK
+最低成立を満たした場合のみ、残す理由を集める。
+
+### 4.3 残す理由あり
+残す理由が1件以上あれば Green とする。
+
+### 4.4 残す理由なし
+最低成立を満たしていても、残す理由がなければ Green にしない。
+
+---
+
+## 5. データ構造
+
+```python
+from dataclasses import dataclass
+from typing import List
+
+@dataclass(frozen=True)
+class GreenDecision:
+    is_green: bool
+    minimum_pass: bool
+    keep_reasons: List[str]
+    reject_reasons: List[str]
+```
+
+### 項目の意味
+- `is_green`: 最終 Green 判定
+- `minimum_pass`: 最低成立を通ったか
+- `keep_reasons`: 残す理由
+- `reject_reasons`: Green にしなかった理由
+
+---
+
+## 6. 実装方針
+
+Green 判定は専用関数に切り出した。
+
+実装配置:
+
+```text
+src/photo_insight/pipelines/evaluation_rank/_internal/green_decision.py
+```
+
+実装した主な関数:
+
+```python
+def is_green_minimum_pass(row: dict, thresholds: dict) -> tuple[bool, list[str]]:
+    ...
+
+def collect_green_keep_reasons(row: dict, thresholds: dict) -> list[str]:
+    ...
+
+def decide_green(row: dict, thresholds: dict) -> GreenDecision:
+    ...
+
+def apply_green_decision_to_row(row: dict, thresholds: dict) -> dict[str, Any]:
+    ...
+```
+
+### 実装上の役割分担
+- `is_green_minimum_pass`
+  - 最低成立判定と reject reason の生成
+- `collect_green_keep_reasons`
+  - keep reason の収集
+- `decide_green`
+  - 最終判定の組み立て
+- `apply_green_decision_to_row`
+  - CSV出力向けの列セットを返す
+
+---
+
+## 7. 閾値管理
+
+閾値は `green_decision` 設定から読み込める構成とした。
+
+```yaml
+green_decision:
+  version: "v2-real"
+  require_face_detected: true
+  min_blurriness_score: 0.50
+  min_composition_score: 0.50
+  min_face_exposure_score: 0.50
+  reject_no_face_shot_type: true
+
+  keep_reason_thresholds:
+    expression_score: 0.75
+    composition_score: 0.75
+    eye_contact_score: 0.75
+    face_position_score: 0.75
+    face_exposure_score: 0.75
+    face_sharpness_score: 0.75
+    pose_score: 75.0
+    pro_composition_strong: 0.85
+    pro_face_composition_strong: 0.85
+```
+
+### 実装上の初期値
+- `version = "v2-real"`
+- `min_blurriness_score = 0.50`
+- `min_composition_score = 0.50`
+- `min_face_exposure_score = 0.50`
+
+※ 数値は初期運用値であり、実データ確認後に微調整可能とする。
+
+---
+
+## 8. keep reason の定義
+
+### 8.1 SNS受け
+以下を keep reason として採用する。
+
+- `sns_expression`
+- `sns_composition`
+- `sns_eye_contact`
+- `sns_face_position`
+
+判定に使う列:
+- `expression_score`
+- `composition_score`
+- `eye_contact_score`
+- `face_position_score`
+
+### 8.2 モデル受け
+以下を keep reason として採用する。
+
+- `model_face_exposure`
+- `model_face_sharpness`
+- `model_pose`
+
+判定に使う列:
+- `face_exposure_score`
+- `face_sharpness_score`
+- `pose_score`
+
+### 8.3 プロ品質
+以下を keep reason として採用する。
+
+- `pro_composition_strong`
+- `pro_face_composition_strong`
+
+判定に使う列:
+- `composition_score`
+- `face_composition_score`
+
+---
+
+## 9. 出力項目
+
+今回の実装で、ranking CSV に以下を追加した。
+
+- `is_green`
+- `green_minimum_pass`
+- `green_keep_reasons`
+- `green_reject_reasons`
+- `green_decision_version`
+
+出力例:
+
+```text
+is_green = 1
+green_minimum_pass = 1
+green_keep_reasons = sns_expression|model_face_exposure
+green_reject_reasons =
+green_decision_version = v2-real
+```
+
+最低成立NGの例:
+
+```text
+is_green = 0
+green_minimum_pass = 0
+green_keep_reasons =
+green_reject_reasons = blurriness_too_low
+green_decision_version = v2-real
+```
+
+### writer / contract 反映
+- `contract.py`
+  - `OUTPUT_COLUMNS` に Green 系列を追加
+- `writer.py`
+  - `is_green`
+  - `green_minimum_pass`
+
+  を 0/1 正規化対象に追加
+
+---
+
+## 10. 本体組み込み
+
+`EvaluationRankBatchProcessor` に Green 判定を組み込んだ。
+
+組み込み位置:
+- `_process_batch()` 内
+- `overall_score` / `score_*` / `contrib_*` 計算後
+- `results.append(...)` の直前
+
+処理イメージ:
+
+```python
+green_updates = apply_green_decision_to_row(
+    out,
+    (self.config_manager.get_config() or {}),
+)
+out.update(green_updates)
+```
+
+これにより、evaluation_rank 本体で算出された行ごとに Green 判定結果が付与される。
+
+---
+
+## 11. テスト方針
+
+以下を単体テストで確認した。
+
+1. `no_face` は minimum pass で落ちる
+2. `face_detected=False` なら Green にならない
+3. 最低成立OKでも理由なしなら Green にならない
+4. SNS理由で Green になる
+5. モデル受け理由で Green になる
+6. 複数理由を保持できる
+7. custom threshold が反映される
+8. writer が Green 系列を出力できる
+
+想定ファイル:
+
+```text
+tests/unit/pipelines/evaluation_rank/test_green_decision.py
+tests/unit/pipelines/evaluation_rank/test_writer_green_columns.py
+```
+
+### 実施結果
+- `tests/unit/pipelines/evaluation_rank/test_green_decision.py` 通過
+- `tests/unit/pipelines/evaluation_rank/test_writer_green_columns.py` 通過
+- `tests/unit/pipelines/evaluation_rank/` 全体通過
+
+---
+
+## 12. 実データ確認結果
+
+実データのCSV列構成を確認した上で、Green 判定に使う列を選定した。
+
+主に使用した列:
+- `shot_type`
+- `face_detected`
+- `blurriness_score`
+- `composition_score`
+- `face_exposure_score`
+- `expression_score`
+- `eye_contact_score`
+- `face_position_score`
+- `face_sharpness_score`
+- `pose_score`
+- `face_composition_score`
+
+確認した内容:
+- Green 系列が ranking CSV に出力される
+- `green_reject_reasons` によって落ちた理由が説明可能
+- `secondary_accept_flag` と `is_green` が独立している
+- 既存 accepted 系との衝突はない
+
+---
+
+## 13. 完了条件
+
+今回の対応で、以下を満たした。
+
+- Green 判定が「最低成立＋残す理由」に置き換わっている
+- 判定理由をコード上で説明できる
+- 単体テストが追加されている
+- ranking CSV に理由が出力される
+- `evaluation_rank` 配下の unit test が全通している
+
+---
+
+## 14. 今回の非目標
+
+今回の対応では以下は直接扱わない。
+
+- portrait / body / non_face の分類拡張
+- 分布健全性チェックそのもの
+- Lightroom UI 全体の見直し
+- ユーザー主観選定の完全再現
+- accepted_flag と Green の統合
+
+---
+
+## 15. 今後の論点
+
+今後の調整候補は以下。
+
+- `min_blurriness_score` の厳しさ調整
+- `min_composition_score` の厳しさ調整
+- SNS受け・モデル受けの精度向上
+- keep reason を Lightroom keyword へ反映するかの検討
+- Green と accepted の関係再整理
+
+---
+
+## 16. まとめ
+
+今回の変更で、Green は次の意味になった。
+
+**Green = 最低成立を満たし、残す理由がある写真**
+
+さらに実装上は、以下の3軸で理由を収集する。
+
+- SNS受け
+- モデル受け
+- プロ品質
+
+これにより、Green の意味を明確化し、判定理由を追えるようにした。
+また、後からの見直しや閾値調整がしやすい構造になった。

--- a/src/photo_insight/pipelines/evaluation_rank/_internal/green_decision.py
+++ b/src/photo_insight/pipelines/evaluation_rank/_internal/green_decision.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+def _is_nan(value: Any) -> bool:
+    try:
+        x = float(value)
+    except Exception:
+        return False
+    return x != x
+
+
+def _to_float(value: Any, default: float = 0.0) -> float:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return float(value)
+    if isinstance(value, (int, float)):
+        if _is_nan(value):
+            return default
+        return float(value)
+
+    text = str(value).strip()
+    if text == "":
+        return default
+
+    try:
+        parsed = float(text)
+    except Exception:
+        return default
+
+    if _is_nan(parsed):
+        return default
+    return parsed
+
+
+def _to_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        if _is_nan(value):
+            return default
+        return value != 0
+
+    text = str(value).strip().lower()
+    if text in {"true", "1", "yes", "y", "on"}:
+        return True
+    if text in {"false", "0", "no", "n", "off", ""}:
+        return False
+    return default
+
+
+def serialize_reason_list(reasons: list[str]) -> str:
+    return "|".join(reason for reason in reasons if reason)
+
+
+@dataclass(frozen=True)
+class KeepReasonThresholds:
+    # SNS受け
+    expression_score: float = 0.75
+    composition_score: float = 0.75
+    eye_contact_score: float = 0.75
+    face_position_score: float = 0.75
+
+    # モデル受け
+    face_exposure_score: float = 0.75
+    face_sharpness_score: float = 0.75
+    pose_score: float = 75.0
+
+    # プロ目線で強い
+    pro_composition_strong: float = 0.85
+    pro_face_composition_strong: float = 0.85
+
+
+@dataclass(frozen=True)
+class GreenDecisionThresholds:
+    version: str = "v2-real"
+
+    # 最低成立
+    require_face_detected: bool = True
+    min_blurriness_score: float = 0.50
+    min_composition_score: float = 0.50
+
+    # 補助条件
+    min_face_exposure_score: float = 0.50
+    reject_no_face_shot_type: bool = True
+
+    keep_reason_thresholds: KeepReasonThresholds = field(default_factory=KeepReasonThresholds)
+
+    @classmethod
+    def from_config(cls, config: Mapping[str, Any] | None) -> "GreenDecisionThresholds":
+        if not config:
+            return cls()
+
+        raw = config.get("green_decision", config)
+        keep_raw = raw.get("keep_reason_thresholds", {})
+
+        return cls(
+            version=str(raw.get("version", "v2-real")),
+            require_face_detected=bool(raw.get("require_face_detected", True)),
+            min_blurriness_score=_to_float(raw.get("min_blurriness_score", 0.50), 0.50),
+            min_composition_score=_to_float(raw.get("min_composition_score", 0.50), 0.50),
+            min_face_exposure_score=_to_float(
+                raw.get("min_face_exposure_score", 0.50),
+                0.50,
+            ),
+            reject_no_face_shot_type=bool(raw.get("reject_no_face_shot_type", True)),
+            keep_reason_thresholds=KeepReasonThresholds(
+                expression_score=_to_float(keep_raw.get("expression_score", 0.75), 0.75),
+                composition_score=_to_float(keep_raw.get("composition_score", 0.75), 0.75),
+                eye_contact_score=_to_float(keep_raw.get("eye_contact_score", 0.75), 0.75),
+                face_position_score=_to_float(keep_raw.get("face_position_score", 0.75), 0.75),
+                face_exposure_score=_to_float(keep_raw.get("face_exposure_score", 0.75), 0.75),
+                face_sharpness_score=_to_float(keep_raw.get("face_sharpness_score", 0.75), 0.75),
+                pose_score=_to_float(keep_raw.get("pose_score", 75.0), 75.0),
+                pro_composition_strong=_to_float(
+                    keep_raw.get("pro_composition_strong", 0.85),
+                    0.85,
+                ),
+                pro_face_composition_strong=_to_float(
+                    keep_raw.get("pro_face_composition_strong", 0.85),
+                    0.85,
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class GreenDecision:
+    is_green: bool
+    minimum_pass: bool
+    keep_reasons: list[str]
+    reject_reasons: list[str]
+
+    def to_row_updates(self, version: str) -> dict[str, Any]:
+        return {
+            "is_green": self.is_green,
+            "green_minimum_pass": self.minimum_pass,
+            "green_keep_reasons": serialize_reason_list(self.keep_reasons),
+            "green_reject_reasons": serialize_reason_list(self.reject_reasons),
+            "green_decision_version": version,
+        }
+
+
+def is_green_minimum_pass(
+    row: Mapping[str, Any],
+    thresholds: GreenDecisionThresholds,
+) -> tuple[bool, list[str]]:
+    reject_reasons: list[str] = []
+
+    shot_type = str(row.get("shot_type", "") or "").strip().lower()
+    face_detected = _to_bool(row.get("face_detected", False), False)
+    blurriness_score = _to_float(row.get("blurriness_score", 0.0), 0.0)
+    composition_score = _to_float(row.get("composition_score", 0.0), 0.0)
+    face_exposure_score = _to_float(row.get("face_exposure_score", 0.0), 0.0)
+
+    if thresholds.reject_no_face_shot_type and shot_type == "no_face":
+        reject_reasons.append("shot_type_no_face")
+
+    if thresholds.require_face_detected and not face_detected:
+        reject_reasons.append("face_not_detected")
+
+    if blurriness_score < thresholds.min_blurriness_score:
+        reject_reasons.append("blurriness_too_low")
+
+    if composition_score < thresholds.min_composition_score:
+        reject_reasons.append("composition_too_low")
+
+    if face_detected and face_exposure_score < thresholds.min_face_exposure_score:
+        reject_reasons.append("face_exposure_too_low")
+
+    return (len(reject_reasons) == 0, reject_reasons)
+
+
+def collect_green_keep_reasons(
+    row: Mapping[str, Any],
+    thresholds: GreenDecisionThresholds,
+) -> list[str]:
+    keep_reasons: list[str] = []
+    t = thresholds.keep_reason_thresholds
+
+    expression_score = _to_float(row.get("expression_score", 0.0), 0.0)
+    composition_score = _to_float(row.get("composition_score", 0.0), 0.0)
+    eye_contact_score = _to_float(row.get("eye_contact_score", 0.0), 0.0)
+    face_position_score = _to_float(row.get("face_position_score", 0.0), 0.0)
+
+    face_exposure_score = _to_float(row.get("face_exposure_score", 0.0), 0.0)
+    face_sharpness_score = _to_float(row.get("face_sharpness_score", 0.0), 0.0)
+    pose_score = _to_float(row.get("pose_score", 0.0), 0.0)
+
+    face_composition_score = _to_float(row.get("face_composition_score", 0.0), 0.0)
+
+    # SNS受け
+    if expression_score >= t.expression_score:
+        keep_reasons.append("sns_expression")
+
+    if composition_score >= t.composition_score:
+        keep_reasons.append("sns_composition")
+
+    if eye_contact_score >= t.eye_contact_score:
+        keep_reasons.append("sns_eye_contact")
+
+    if face_position_score >= t.face_position_score:
+        keep_reasons.append("sns_face_position")
+
+    # モデル受け
+    if face_exposure_score >= t.face_exposure_score:
+        keep_reasons.append("model_face_exposure")
+
+    if face_sharpness_score >= t.face_sharpness_score:
+        keep_reasons.append("model_face_sharpness")
+
+    if pose_score >= t.pose_score:
+        keep_reasons.append("model_pose")
+
+    # プロ目線
+    if composition_score >= t.pro_composition_strong:
+        keep_reasons.append("pro_composition_strong")
+
+    if face_composition_score >= t.pro_face_composition_strong:
+        keep_reasons.append("pro_face_composition_strong")
+
+    # 順序維持で重複排除
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for reason in keep_reasons:
+        if reason not in seen:
+            seen.add(reason)
+            deduped.append(reason)
+
+    return deduped
+
+
+def decide_green(
+    row: Mapping[str, Any],
+    thresholds: GreenDecisionThresholds | Mapping[str, Any] | None = None,
+) -> GreenDecision:
+    resolved_thresholds = (
+        thresholds
+        if isinstance(thresholds, GreenDecisionThresholds)
+        else GreenDecisionThresholds.from_config(thresholds)
+    )
+
+    minimum_pass, reject_reasons = is_green_minimum_pass(
+        row=row,
+        thresholds=resolved_thresholds,
+    )
+
+    if not minimum_pass:
+        return GreenDecision(
+            is_green=False,
+            minimum_pass=False,
+            keep_reasons=[],
+            reject_reasons=reject_reasons,
+        )
+
+    keep_reasons = collect_green_keep_reasons(
+        row=row,
+        thresholds=resolved_thresholds,
+    )
+
+    final_reject_reasons = list(reject_reasons)
+    if not keep_reasons:
+        final_reject_reasons.append("no_keep_reason")
+
+    return GreenDecision(
+        is_green=(len(keep_reasons) > 0),
+        minimum_pass=True,
+        keep_reasons=keep_reasons,
+        reject_reasons=final_reject_reasons,
+    )
+
+
+def apply_green_decision_to_row(
+    row: Mapping[str, Any],
+    thresholds: GreenDecisionThresholds | Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    resolved_thresholds = (
+        thresholds
+        if isinstance(thresholds, GreenDecisionThresholds)
+        else GreenDecisionThresholds.from_config(thresholds)
+    )
+    decision = decide_green(row=row, thresholds=resolved_thresholds)
+    return decision.to_row_updates(version=resolved_thresholds.version)
+
+
+__all__ = [
+    "GreenDecision",
+    "GreenDecisionThresholds",
+    "KeepReasonThresholds",
+    "apply_green_decision_to_row",
+    "collect_green_keep_reasons",
+    "decide_green",
+    "is_green_minimum_pass",
+    "serialize_reason_list",
+]

--- a/src/photo_insight/pipelines/evaluation_rank/contract.py
+++ b/src/photo_insight/pipelines/evaluation_rank/contract.py
@@ -154,6 +154,11 @@ OUTPUT_COLUMNS = [
     "flag",
     "accepted_flag",
     "secondary_accept_flag",
+    "is_green",
+    "green_minimum_pass",
+    "green_keep_reasons",
+    "green_reject_reasons",
+    "green_decision_version",
     # --- #706-1 provisional accepted (top%) ---
     "provisional_top_percent_flag",
     "provisional_top_percent",

--- a/src/photo_insight/pipelines/evaluation_rank/evaluation_rank_batch_processor.py
+++ b/src/photo_insight/pipelines/evaluation_rank/evaluation_rank_batch_processor.py
@@ -31,6 +31,7 @@ from .scoring import (
     score01,
 )
 from .writer import write_ranking_csv
+from ._internal.green_decision import apply_green_decision_to_row
 from .analysis.provisional_vs_accepted import (
     build_provisional_vs_accepted_summary,
     write_provisional_vs_accepted_summary_csv,
@@ -535,6 +536,12 @@ class EvaluationRankBatchProcessor(BaseBatchProcessor):
                     out[f"contrib_face_{k}"] = safe_float(v) * 100.0
                 for k, v in (comp_bd or {}).items():
                     out[f"contrib_comp_{k}"] = safe_float(v) * 100.0
+
+                green_updates = apply_green_decision_to_row(
+                    out,
+                    (self.config_manager.get_config() or {}),
+                )
+                out.update(green_updates)
 
                 results.append({"status": "success", "score": float(overall), "row": out})
 

--- a/src/photo_insight/pipelines/evaluation_rank/writer.py
+++ b/src/photo_insight/pipelines/evaluation_rank/writer.py
@@ -113,7 +113,13 @@ def _normalize_row_for_output(row: Dict[str, Any], columns: Sequence[str]) -> Di
         if v is None:
             v = ""
 
-        if c in ("flag", "accepted_flag", "secondary_accept_flag"):
+        if c in (
+            "flag",
+            "accepted_flag",
+            "secondary_accept_flag",
+            "is_green",
+            "green_minimum_pass",
+        ):
             v = safe_int_flag(v)
 
         out[c] = v

--- a/tests/unit/pipelines/evaluation_rank/test_green_decision.py
+++ b/tests/unit/pipelines/evaluation_rank/test_green_decision.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from photo_insight.pipelines.evaluation_rank._internal.green_decision import (
+    GreenDecisionThresholds,
+    apply_green_decision_to_row,
+    decide_green,
+)
+
+
+def _base_row(**overrides):
+    row = {
+        "file_name": "test.NEF",
+        "shot_type": "face_only",
+        "face_detected": True,
+        "blurriness_score": 0.75,
+        "composition_score": 0.70,
+        "face_exposure_score": 0.70,
+        "face_sharpness_score": 0.70,
+        "face_composition_score": 0.70,
+        "expression_score": 0.50,
+        "eye_contact_score": 0.50,
+        "face_position_score": 0.50,
+        "pose_score": 50.0,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_decide_green_rejects_no_face_shot_type():
+    row = _base_row(
+        shot_type="no_face",
+        face_detected=False,
+    )
+
+    decision = decide_green(row)
+
+    assert decision.minimum_pass is False
+    assert decision.is_green is False
+    assert "shot_type_no_face" in decision.reject_reasons
+
+
+def test_decide_green_rejects_when_face_not_detected():
+    row = _base_row(face_detected=False)
+
+    decision = decide_green(row)
+
+    assert decision.minimum_pass is False
+    assert decision.is_green is False
+    assert "face_not_detected" in decision.reject_reasons
+
+
+def test_decide_green_rejects_when_minimum_pass_ok_but_no_keep_reason():
+    row = _base_row(
+        expression_score=0.50,
+        composition_score=0.60,
+        eye_contact_score=0.40,
+        face_position_score=0.40,
+        face_exposure_score=0.60,
+        face_sharpness_score=0.60,
+        face_composition_score=0.60,
+        pose_score=60.0,
+    )
+
+    decision = decide_green(row)
+
+    assert decision.minimum_pass is True
+    assert decision.is_green is False
+    assert decision.keep_reasons == []
+    assert "no_keep_reason" in decision.reject_reasons
+
+
+def test_decide_green_accepts_with_sns_expression_reason():
+    row = _base_row(
+        expression_score=0.90,
+        composition_score=0.70,
+    )
+
+    decision = decide_green(row)
+
+    assert decision.minimum_pass is True
+    assert decision.is_green is True
+    assert "sns_expression" in decision.keep_reasons
+
+
+def test_decide_green_accepts_with_model_face_exposure_reason():
+    row = _base_row(
+        face_exposure_score=0.90,
+    )
+
+    decision = decide_green(row)
+
+    assert decision.minimum_pass is True
+    assert decision.is_green is True
+    assert "model_face_exposure" in decision.keep_reasons
+
+
+def test_decide_green_collects_multiple_keep_reasons():
+    row = _base_row(
+        expression_score=0.90,
+        eye_contact_score=0.80,
+        face_exposure_score=0.92,
+        face_sharpness_score=0.88,
+        face_composition_score=0.90,
+        composition_score=0.87,
+        pose_score=88.0,
+    )
+
+    decision = decide_green(row)
+
+    assert decision.minimum_pass is True
+    assert decision.is_green is True
+    assert "sns_expression" in decision.keep_reasons
+    assert "sns_eye_contact" in decision.keep_reasons
+    assert "model_face_exposure" in decision.keep_reasons
+    assert "model_face_sharpness" in decision.keep_reasons
+    assert "pro_composition_strong" in decision.keep_reasons
+    assert "pro_face_composition_strong" in decision.keep_reasons
+    assert "model_pose" in decision.keep_reasons
+
+
+def test_apply_green_decision_to_row_returns_expected_fields():
+    row = _base_row(expression_score=0.90)
+
+    updates = apply_green_decision_to_row(row)
+
+    assert set(updates.keys()) == {
+        "is_green",
+        "green_minimum_pass",
+        "green_keep_reasons",
+        "green_reject_reasons",
+        "green_decision_version",
+    }
+    assert updates["is_green"] is True
+    assert updates["green_minimum_pass"] is True
+    assert "sns_expression" in updates["green_keep_reasons"]
+    assert updates["green_decision_version"] == "v2-real"
+
+
+def test_decide_green_respects_custom_thresholds():
+    thresholds = GreenDecisionThresholds.from_config(
+        {
+            "green_decision": {
+                "min_blurriness_score": 0.80,
+                "min_composition_score": 0.80,
+                "keep_reason_thresholds": {
+                    "expression_score": 0.95,
+                },
+            }
+        }
+    )
+
+    row = _base_row(
+        blurriness_score=0.75,
+        composition_score=0.70,
+        expression_score=0.90,
+    )
+
+    decision = decide_green(row, thresholds)
+
+    assert decision.minimum_pass is False
+    assert decision.is_green is False
+    assert "blurriness_too_low" in decision.reject_reasons
+    assert "composition_too_low" in decision.reject_reasons

--- a/tests/unit/pipelines/evaluation_rank/test_writer_green_columns.py
+++ b/tests/unit/pipelines/evaluation_rank/test_writer_green_columns.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import csv
+
+from photo_insight.pipelines.evaluation_rank.writer import write_ranking_csv
+
+
+def test_write_ranking_csv_includes_green_columns(tmp_path):
+    output_csv = tmp_path / "ranking.csv"
+
+    rows = [
+        {
+            "file_name": "a.NEF",
+            "group_id": "A",
+            "subgroup_id": "1",
+            "shot_type": "face_only",
+            "face_detected": True,
+            "category": "portrait",
+            "overall_score": 0.88,
+            "flag": 0,
+            "accepted_flag": 1,
+            "secondary_accept_flag": 0,
+            "is_green": True,
+            "green_minimum_pass": True,
+            "green_keep_reasons": "sns_expression|model_face_exposure",
+            "green_reject_reasons": "",
+            "green_decision_version": "v2-real",
+            "provisional_top_percent_flag": 0,
+            "provisional_top_percent": 0,
+            "accepted_reason": "accepted",
+        }
+    ]
+
+    columns = write_ranking_csv(
+        output_csv=output_csv,
+        rows=rows,
+        sort_for_ranking=False,
+    )
+
+    assert "is_green" in columns
+    assert "green_minimum_pass" in columns
+    assert "green_keep_reasons" in columns
+    assert "green_reject_reasons" in columns
+    assert "green_decision_version" in columns
+
+    with output_csv.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        row = next(reader)
+
+    assert row["is_green"] == "1"
+    assert row["green_minimum_pass"] == "1"
+    assert row["green_keep_reasons"] == "sns_expression|model_face_exposure"
+    assert row["green_decision_version"] == "v2-real"


### PR DESCRIPTION
## 概要
- Green判定の再定義
- branch: `fix/322-green`

## 対応内容
- 実装内容を記載
- テスト内容を記載
- 必要ならドキュメント更新を記載

## 確認
- [x] ローカルで動作確認
- [x] pytest 実行
- [x] 影響範囲確認

## 関連
Closes #322