### PR TITLE
Fix: [2026-0032] branch-cleanup を squash merge 対応にする (#330)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,14 @@ SYNC_ISSUES_ENV ?= .env
 GITHUB_REPO ?= akky0108/photo_insight
 DOCKER_SYNC_SERVICE ?= app-ci
 
+# =========================
+# Branch cleanup
+# =========================
+BASE_BRANCH ?= develop
+REMOTE_NAME ?= origin
+DELETE_REMOTE ?= true
+TARGET_BRANCH ?=
+
 .DEFAULT_GOAL := help
 
 .PHONY: help merge dry-run only-pip audit clean check-ci-env lint fmt fmt-check test \
@@ -36,7 +44,8 @@ DOCKER_SYNC_SERVICE ?= app-ci
         docker-build docker-shell docker-ci docker-ci-light docker-test \
         docker-integration docker-lint docker-fmt-check docker-ci-gpu \
         sync-issues sync-issues-dry docker-sync-issues docker-sync-issues-dry \
-        issue-new issue-start pr-create pr-draft branch-cleanup cur st lg
+        issue-new issue-start pr-create pr-draft branch-cleanup branch-cleanup-current \
+        release-pr release-pr-draft cur st lg
 
 help:
 	@echo "Available commands:"
@@ -62,6 +71,8 @@ help:
 	@echo "  make docker-sync-issues-dry  Run issue sync in Docker (dry-run)"
 	@echo "  make docker-sync-issues      Run issue sync in Docker"
 	@echo "  make issue-new TITLE=\"...\"  Create GitHub Issue and start work branch"
+	@echo "  make branch-cleanup TARGET_BRANCH=fix/xxx"
+	@echo "  make branch-cleanup-current"
 
 merge:
 	@if [ ! -f $(PIP_JSON) ]; then \
@@ -230,13 +241,24 @@ pr-create:
 pr-draft:
 	./scripts/github/create_pr.sh --draft
 
-# ブランチ cleanup（現在ブランチ or 指定）
+# ブランチ cleanup（明示指定）
 branch-cleanup:
-	@if [ -n "$(BRANCH)" ]; then \
-		./scripts/github/cleanup_branch.sh $(BRANCH); \
-	else \
-		./scripts/github/cleanup_branch.sh; \
+	@if [ -z "$(TARGET_BRANCH)" ]; then \
+		echo "[ERROR] TARGET_BRANCH is required."; \
+		echo "Example: make branch-cleanup TARGET_BRANCH=fix/316-2026-0029-portrait-body"; \
+		exit 1; \
 	fi
+	@BASE_BRANCH="$(BASE_BRANCH)" \
+	REMOTE_NAME="$(REMOTE_NAME)" \
+	DELETE_REMOTE="$(DELETE_REMOTE)" \
+	./scripts/github/cleanup_branch.sh "$(TARGET_BRANCH)"
+
+# ブランチ cleanup（現在ブランチ対象）
+branch-cleanup-current:
+	@BASE_BRANCH="$(BASE_BRANCH)" \
+	REMOTE_NAME="$(REMOTE_NAME)" \
+	DELETE_REMOTE="$(DELETE_REMOTE)" \
+	./scripts/github/cleanup_branch.sh
 
 # develop → main リリースPR
 release-pr:

--- a/scripts/github/cleanup_branch.sh
+++ b/scripts/github/cleanup_branch.sh
@@ -39,6 +39,11 @@ require_command() {
   fi
 }
 
+has_command() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1
+}
+
 ensure_git_repo() {
   if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     echo "[ERROR] Not inside a git repository." >&2
@@ -105,6 +110,64 @@ switch_to_base_branch() {
 is_merged_into_base() {
   local branch_name="$1"
   git merge-base --is-ancestor "$branch_name" "$BASE_BRANCH"
+}
+
+gh_is_available_and_authenticated() {
+  if ! has_command gh; then
+    return 1
+  fi
+
+  gh auth status >/dev/null 2>&1
+}
+
+find_merged_pr_number() {
+  local branch_name="$1"
+
+  gh pr list \
+    --state merged \
+    --base "$BASE_BRANCH" \
+    --head "$branch_name" \
+    --limit 1 \
+    --json number \
+    --jq '.[0].number // ""'
+}
+
+is_merged_via_github_pr() {
+  local branch_name="$1"
+
+  if ! gh_is_available_and_authenticated; then
+    return 1
+  fi
+
+  local pr_number=""
+  pr_number="$(find_merged_pr_number "$branch_name" || true)"
+
+  [[ -n "$pr_number" ]]
+}
+
+print_github_merge_hint() {
+  local branch_name="$1"
+
+  if ! gh_is_available_and_authenticated; then
+    echo "[INFO] gh is not available or not authenticated. GitHub merged PR check skipped."
+    return 0
+  fi
+
+  local pr_info=""
+  pr_info="$(
+    gh pr list \
+      --state merged \
+      --base "$BASE_BRANCH" \
+      --head "$branch_name" \
+      --limit 1 \
+      --json number,title,url,mergedAt \
+      --jq '.[0] | "PR #\(.number) merged at \(.mergedAt): \(.title) (\(.url))"' \
+      2>/dev/null || true
+  )"
+
+  if [[ -n "$pr_info" ]]; then
+    echo "[INFO] $pr_info"
+  fi
 }
 
 delete_local_branch() {
@@ -178,10 +241,17 @@ main() {
 
   if branch_exists_local "$target_branch"; then
     if is_merged_into_base "$target_branch"; then
+      echo "[INFO] Branch is merged into $BASE_BRANCH by git ancestry."
       delete_local_branch "$target_branch"
+    elif is_merged_via_github_pr "$target_branch"; then
+      echo "[INFO] Branch is not merged by git ancestry, but GitHub shows a merged PR."
+      echo "[INFO] Treating this as squash/rebase merged and proceeding."
+      print_github_merge_hint "$target_branch"
+      force_delete_local_branch "$target_branch"
     else
       echo "[WARN] Branch is not merged into $BASE_BRANCH: $target_branch"
-      echo "[WARN] Refusing normal delete."
+      echo "[WARN] No merged GitHub PR was found for this branch."
+      echo "[WARN] Refusing delete."
       echo "[WARN] If you really want to discard it, run:"
       echo "       git branch -D \"$target_branch\""
       exit 1
@@ -190,7 +260,13 @@ main() {
 
   if [[ "$delete_remote" == "true" ]]; then
     if branch_exists_remote "$target_branch"; then
-      delete_remote_branch "$target_branch"
+      if is_merged_via_github_pr "$target_branch" || ! branch_exists_local "$target_branch"; then
+        delete_remote_branch "$target_branch"
+      else
+        echo "[WARN] Remote branch still exists, but no merged PR was confirmed."
+        echo "[WARN] Refusing remote delete."
+        exit 1
+      fi
     else
       echo "[INFO] Remote branch does not exist: $REMOTE_NAME/$target_branch"
     fi
@@ -200,4 +276,5 @@ main() {
   echo "[OK] Cleanup completed."
   echo "Current branch: $(git branch --show-current)"
 }
+
 main "$@"


### PR DESCRIPTION
## 概要
- [2026-0032] branch-cleanup を squash merge 対応にする
- branch: `fix/330-2026-0032-branch-cleanup-squash-merge`

## 変更内容
- cleanup_branch.sh に GitHub PR の merged 判定を追加
- Git の ancestry 判定で未マージでも、GitHub 上で merged PR が確認できれば cleanup を続行
- Makefile の branch-cleanup を TARGET_BRANCH 明示型に変更
- branch-cleanup-current を追加

## 背景
develop への squash merge 後、従来の Git ancestry 判定だけでは未マージ扱いとなり、
自動 cleanup が止まっていたため。

## 効果
- squash / merge commit / rebase merge のいずれでも cleanup しやすくなる
- develop/main の squash merge 運用と自動化が整合する

## 確認
- [x] ローカルで動作確認
- [x] pytest 実行
- [x] 影響範囲確認

## 関連
Closes #330