### PR TITLE
Feat: [2026-0031] 分布健全性チェック導入（score_dist_tune + Criteria7015） (#318)

### DIFF
--- a/.github/issues/epics.yaml
+++ b/.github/issues/epics.yaml
@@ -790,9 +790,13 @@ issues:
 
     children:
       - issue_portrait_category_split
+      - issue_hard_gate_foundation
       - issue_hard_gate_face
       - issue_hard_gate_body
+      - issue_evaluation_responsibility_split
       - issue_green_definition
+      - issue_evaluation_rank_three_category_compat
+      - issue_portrait_quality_csv_schema_contract
       - issue_distribution_validation
 
   - id: issue_portrait_category_split
@@ -906,6 +910,107 @@ issues:
       ## 完了条件
       - validation_pass が維持される
       - accepted率の急変が発生しない
+
+    labels:
+      - enhancement
+
+  - id: issue_hard_gate_foundation
+    title: "[2026-0032] hard gate 基盤導入（reject / reason / contract）"
+    body: |
+      ## 概要
+      ハードゲートの責務とデータ構造を統一し、後続実装の破綻を防ぐ。
+
+      ## 問題
+      - hard gate ロジックが face/body 個別実装に分散するリスクがある
+      - reject と accepted_flag の関係が未固定
+      - reject 理由の出力契約が未定義
+
+      ## 対応内容
+      - reject フラグの正式定義
+      - reject_reason の構造定義
+      - 適用ポイントの明確化
+      - accepted_flag との関係整理
+      - CSV出力フォーマット設計
+
+      ## 完了条件
+      - hard gate の共通契約が定義される
+      - 後続の face/body gate が同じ契約で実装できる
+      - 既存の score / category 処理と責務が分離される
+
+    labels:
+      - enhancement
+
+  - id: issue_evaluation_responsibility_split
+    title: "[2026-0033] 評価責務の分離（category / gate / score / accept）"
+    body: |
+      ## 概要
+      category / gate / score / accept の責務を整理し、評価ロジックの混在を防ぐ。
+
+      ## 問題
+      - 分類、reject、スコア、Green判定の責務境界が曖昧
+      - score が reject や Green 判定に混入するリスクがある
+
+      ## 対応内容
+      - category は分類のみと定義
+      - gate は reject 判定のみと定義
+      - score は順位付けのみと定義
+      - accept は Green/Red 判定として定義
+      - 禁止事項を明文化する
+
+      ## 完了条件
+      - 各責務の境界が明文化される
+      - score による reject / Green 判定が禁止事項として整理される
+      - 後続Issueの実装方針がぶれない
+
+    labels:
+      - enhancement
+
+  - id: issue_evaluation_rank_three_category_compat
+    title: "[2026-0034] evaluation_rank の3分類対応（互換維持）"
+    body: |
+      ## 概要
+      portrait_face / portrait_body / non_face 導入後の evaluation_rank 側の扱いを整理する。
+
+      ## 問題
+      - evaluation_rank は legacy category（portrait / non_face）前提の処理が多い
+      - portrait_face / portrait_body を直接扱う範囲が未定義
+      - downstream 影響が見えにくい
+
+      ## 対応内容
+      - portrait_face / portrait_body の扱い整理
+      - legacy category（portrait / non_face）との整合性維持
+      - ranking 条件の見直し
+      - downstream 影響確認
+
+      ## 完了条件
+      - evaluation_rank が3分類情報を安全に扱える
+      - legacy category 互換が維持される
+      - ranking 条件の変更有無が明確になる
+
+    labels:
+      - enhancement
+
+  - id: issue_portrait_quality_csv_schema_contract
+    title: "[2026-0035] portrait_quality CSV schema 契約固定"
+    body: |
+      ## 概要
+      portrait_quality の出力CSV契約を固定し、後方互換と validation を安定化する。
+
+      ## 問題
+      - portrait_category の必須/任意扱いが未固定
+      - 今後追加される reject 系カラムの契約が未定義
+      - downstream の期待カラムが曖昧になりやすい
+
+      ## 対応内容
+      - portrait_category の必須/任意定義
+      - reject 系カラムの追加設計
+      - CSV validation ルール更新
+      - schema ドキュメント化
+
+      ## 完了条件
+      - portrait_quality CSV の契約が明文化される
+      - validation が schema と整合する
+      - downstream が期待カラムを判断できる
 
     labels:
       - enhancement

--- a/src/photo_insight/pipelines/evaluation_rank/criteria7015.py
+++ b/src/photo_insight/pipelines/evaluation_rank/criteria7015.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .distribution_health import DistributionHealthMetrics
+
+
+@dataclass(frozen=True)
+class Criteria7015Result:
+    """Criteria7015 の判定結果。"""
+
+    validation_pass: bool
+    reasons: list[str]
+
+
+@dataclass(frozen=True)
+class Criteria7015Thresholds:
+    """分布健全性の判定閾値。"""
+
+    accepted_ratio_min: float = 0.1
+    accepted_ratio_max: float = 0.9
+
+    saturation_ratio_max: float = 0.2
+
+    discrete_ratio_max: float = 0.5
+
+
+def evaluate_criteria7015(
+    metrics: DistributionHealthMetrics,
+    thresholds: Criteria7015Thresholds | None = None,
+) -> Criteria7015Result:
+    """分布健全性を Criteria7015 に基づいて評価する。
+
+    Args:
+        metrics:
+            distribution_health で算出されたメトリクス。
+        thresholds:
+            判定閾値（未指定ならデフォルト）。
+
+    Returns:
+        Criteria7015Result:
+            validation_pass と失敗理由一覧。
+    """
+
+    if thresholds is None:
+        thresholds = Criteria7015Thresholds()
+
+    reasons: list[str] = []
+
+    # accepted_ratio チェック
+    if metrics.accepted_ratio < thresholds.accepted_ratio_min:
+        reasons.append(f"accepted_ratio too low: {metrics.accepted_ratio:.3f}")
+
+    if metrics.accepted_ratio > thresholds.accepted_ratio_max:
+        reasons.append(f"accepted_ratio too high: {metrics.accepted_ratio:.3f}")
+
+    # saturation_ratio チェック
+    if metrics.saturation_ratio > thresholds.saturation_ratio_max:
+        reasons.append(f"saturation_ratio too high: {metrics.saturation_ratio:.3f}")
+
+    # discrete_ratio チェック
+    if metrics.discrete_ratio > thresholds.discrete_ratio_max:
+        reasons.append(f"discrete_ratio too high: {metrics.discrete_ratio:.3f}")
+
+    validation_pass = len(reasons) == 0
+
+    return Criteria7015Result(
+        validation_pass=validation_pass,
+        reasons=reasons,
+    )

--- a/src/photo_insight/pipelines/evaluation_rank/distribution_health.py
+++ b/src/photo_insight/pipelines/evaluation_rank/distribution_health.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class DistributionHealthMetrics:
+    """評価結果CSVから算出した分布健全性メトリクス。"""
+
+    total_count: int
+    accepted_count: int
+    accepted_ratio: float
+    saturation_ratio: float
+    discrete_ratio: float
+
+
+def calculate_distribution_health(
+    csv_path: str | Path,
+    *,
+    score_column: str = "score",
+    decision_column: str = "decision",
+    accepted_value: str = "accepted",
+    saturation_min_score: float = 0.0,
+    saturation_max_score: float = 100.0,
+) -> DistributionHealthMetrics:
+    """評価結果CSVから分布健全性メトリクスを算出する。
+
+    Args:
+        csv_path:
+            evaluation_results_*.csv のパス。
+        score_column:
+            スコア列名。
+        decision_column:
+            判定列名。
+        accepted_value:
+            accepted とみなす値。
+        saturation_min_score:
+            下限飽和とみなすスコア。
+        saturation_max_score:
+            上限飽和とみなすスコア。
+
+    Returns:
+        DistributionHealthMetrics:
+            accepted_ratio / saturation_ratio / discrete_ratio を含む結果。
+
+    Raises:
+        FileNotFoundError:
+            CSV が存在しない場合。
+        ValueError:
+            必須列が不足している場合。
+    """
+
+    path = Path(csv_path)
+
+    if not path.exists():
+        raise FileNotFoundError(f"CSV file not found: {path}")
+
+    df = pd.read_csv(path)
+
+    required_columns = {score_column, decision_column}
+    missing_columns = required_columns - set(df.columns)
+
+    if missing_columns:
+        raise ValueError("Missing required columns: " + ", ".join(sorted(missing_columns)))
+
+    total_count = len(df)
+
+    if total_count == 0:
+        return DistributionHealthMetrics(
+            total_count=0,
+            accepted_count=0,
+            accepted_ratio=0.0,
+            saturation_ratio=0.0,
+            discrete_ratio=0.0,
+        )
+
+    scores = pd.to_numeric(df[score_column], errors="coerce")
+
+    accepted_count = int((df[decision_column] == accepted_value).sum())
+    accepted_ratio = accepted_count / total_count
+
+    saturation_count = int(((scores <= saturation_min_score) | (scores >= saturation_max_score)).sum())
+    saturation_ratio = saturation_count / total_count
+
+    score_counts = scores.value_counts(dropna=True)
+
+    if score_counts.empty:
+        discrete_ratio = 0.0
+    else:
+        discrete_ratio = int(score_counts.max()) / total_count
+
+    return DistributionHealthMetrics(
+        total_count=total_count,
+        accepted_count=accepted_count,
+        accepted_ratio=accepted_ratio,
+        saturation_ratio=saturation_ratio,
+        discrete_ratio=discrete_ratio,
+    )

--- a/src/photo_insight/pipelines/evaluation_rank/evaluation_rank_batch_processor.py
+++ b/src/photo_insight/pipelines/evaluation_rank/evaluation_rank_batch_processor.py
@@ -44,6 +44,12 @@ from photo_insight.evaluators.common.grade_contract import (
 from .provisional import (
     apply_provisional_top_percent,
 )
+from photo_insight.pipelines.evaluation_rank.criteria7015 import (
+    evaluate_criteria7015,
+)
+from photo_insight.pipelines.evaluation_rank.distribution_health import (
+    calculate_distribution_health,
+)
 
 # =========================
 # utility
@@ -606,6 +612,9 @@ class EvaluationRankBatchProcessor(BaseBatchProcessor):
             # rejected_reason（既存）
             self._write_rejected_reason_summary(rows)
 
+            # distribution health（#318）
+            self._write_distribution_health_summary(output_csv)
+
             self._log_thresholds(thresholds)
             self.logger.info(f"Columns written: {len(columns)} cols")
 
@@ -780,6 +789,49 @@ class EvaluationRankBatchProcessor(BaseBatchProcessor):
 
         except Exception as e:
             self.logger.warning(f"[rejected_reason] failed to write summary: {e}")
+
+    def _write_distribution_health_summary(self, ranking_csv_path: Path) -> None:
+        """評価ランキングCSVから分布健全性チェック結果を出力する。"""
+
+        try:
+            metrics = calculate_distribution_health(
+                ranking_csv_path,
+                score_column="overall_score",
+                decision_column="accepted_flag",
+                accepted_value=1,
+            )
+            criteria_result = evaluate_criteria7015(metrics)
+
+            out_dir = Path(self.paths["output_data_dir"])
+            out_dir.mkdir(parents=True, exist_ok=True)
+
+            out_path = out_dir / f"distribution_health_summary_{self.date}.csv"
+
+            with out_path.open("w", encoding="utf-8", newline="") as f:
+                f.write(
+                    "validation_pass,total_count,accepted_count,"
+                    "accepted_ratio,saturation_ratio,discrete_ratio,reasons\n"
+                )
+                f.write(
+                    f"{criteria_result.validation_pass},"
+                    f"{metrics.total_count},"
+                    f"{metrics.accepted_count},"
+                    f"{metrics.accepted_ratio:.6f},"
+                    f"{metrics.saturation_ratio:.6f},"
+                    f"{metrics.discrete_ratio:.6f},"
+                    f"\"{' | '.join(criteria_result.reasons)}\"\n"
+                )
+
+            self.logger.info(
+                "[distribution_health] "
+                f"pass={criteria_result.validation_pass} "
+                f"A={metrics.accepted_ratio:.3f} "
+                f"S={metrics.saturation_ratio:.3f} "
+                f"D={metrics.discrete_ratio:.3f}"
+            )
+
+        except Exception as e:
+            self.logger.warning(f"[distribution_health] failed: {e}")
 
     def _apply_provisional_top_percent(self, rows: list[dict[str, Any]]) -> None:
         """

--- a/tests/unit/pipelines/evaluation_rank/test_criteria7015.py
+++ b/tests/unit/pipelines/evaluation_rank/test_criteria7015.py
@@ -1,0 +1,66 @@
+from photo_insight.pipelines.evaluation_rank.criteria7015 import (
+    evaluate_criteria7015,
+)
+from photo_insight.pipelines.evaluation_rank.distribution_health import (
+    DistributionHealthMetrics,
+)
+
+
+def test_criteria7015_pass():
+    metrics = DistributionHealthMetrics(
+        total_count=100,
+        accepted_count=50,
+        accepted_ratio=0.5,
+        saturation_ratio=0.05,
+        discrete_ratio=0.1,
+    )
+
+    result = evaluate_criteria7015(metrics)
+
+    assert result.validation_pass is True
+    assert result.reasons == []
+
+
+def test_criteria7015_fail_accepted_ratio():
+    metrics = DistributionHealthMetrics(
+        total_count=100,
+        accepted_count=95,
+        accepted_ratio=0.95,
+        saturation_ratio=0.05,
+        discrete_ratio=0.1,
+    )
+
+    result = evaluate_criteria7015(metrics)
+
+    assert result.validation_pass is False
+    assert any("accepted_ratio" in r for r in result.reasons)
+
+
+def test_criteria7015_fail_saturation():
+    metrics = DistributionHealthMetrics(
+        total_count=100,
+        accepted_count=50,
+        accepted_ratio=0.5,
+        saturation_ratio=0.3,
+        discrete_ratio=0.1,
+    )
+
+    result = evaluate_criteria7015(metrics)
+
+    assert result.validation_pass is False
+    assert any("saturation_ratio" in r for r in result.reasons)
+
+
+def test_criteria7015_fail_discrete():
+    metrics = DistributionHealthMetrics(
+        total_count=100,
+        accepted_count=50,
+        accepted_ratio=0.5,
+        saturation_ratio=0.05,
+        discrete_ratio=0.8,
+    )
+
+    result = evaluate_criteria7015(metrics)
+
+    assert result.validation_pass is False
+    assert any("discrete_ratio" in r for r in result.reasons)

--- a/tests/unit/pipelines/evaluation_rank/test_distribution_health.py
+++ b/tests/unit/pipelines/evaluation_rank/test_distribution_health.py
@@ -1,0 +1,48 @@
+import pandas as pd
+from pathlib import Path
+
+from photo_insight.pipelines.evaluation_rank.distribution_health import (
+    calculate_distribution_health,
+)
+
+
+def test_distribution_health_basic(tmp_path: Path):
+    csv_path = tmp_path / "test.csv"
+
+    df = pd.DataFrame(
+        {
+            "score": [10, 50, 90, 100],
+            "decision": ["accepted", "rejected", "accepted", "accepted"],
+        }
+    )
+    df.to_csv(csv_path, index=False)
+
+    result = calculate_distribution_health(csv_path)
+
+    assert result.total_count == 4
+    assert result.accepted_count == 3
+    assert result.accepted_ratio == 3 / 4
+
+
+def test_distribution_health_empty(tmp_path: Path):
+    csv_path = tmp_path / "test.csv"
+
+    df = pd.DataFrame(columns=["score", "decision"])
+    df.to_csv(csv_path, index=False)
+
+    result = calculate_distribution_health(csv_path)
+
+    assert result.total_count == 0
+    assert result.accepted_ratio == 0.0
+
+
+def test_distribution_health_missing_column(tmp_path: Path):
+    csv_path = tmp_path / "test.csv"
+
+    df = pd.DataFrame({"score": [10, 20]})
+    df.to_csv(csv_path, index=False)
+
+    import pytest
+
+    with pytest.raises(ValueError):
+        calculate_distribution_health(csv_path)


### PR DESCRIPTION
## 概要
- [2026-0031] 分布健全性チェック導入（score_dist_tune + Criteria7015）
- branch: `feat/318-2026-0031-score-dist-tune-criteria7015`

## 対応内容
Adds distribution health validation for evaluation ranking output.

- Calculates accepted_ratio / saturation_ratio / discrete_ratio
- Adds Criteria7015 validation
- Outputs distribution_health_summary_YYYY-MM-DD.csv
- Validates final evaluation_ranking output

## 確認
- [x] ローカルで動作確認
- [x] pytest 実行
- [x] 影響範囲確認

## 関連
Closes #318